### PR TITLE
Remove menu toggle button and script

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
   <header>
     <div class="container">
       <h1>Alex Chesnay</h1>
-      <button id="menu-toggle" aria-label="Menu">☰</button>
       <nav>
         <ul>
           <li><a href="#accueil">Accueil</a></li>

--- a/js/script.js
+++ b/js/script.js
@@ -5,14 +5,6 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-  const menuToggle = document.querySelector('#menu-toggle');
-  const nav = document.querySelector('nav ul');
-
-  if (menuToggle) {
-    menuToggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-    });
-  }
 
   // ----- Filtrage des cartes de projets -----
   const filterButtons = document.querySelectorAll('.filter-btn');


### PR DESCRIPTION
## Summary
- remove the mobile menu button from the header
- clean up JavaScript by deleting menu toggle handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965738054483249ed87fd7bda48a2e