### PR TITLE
Expand portfolio section to full width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,9 +36,11 @@ nav {
 }
 
 .portfolio {
-  max-width: 1100px;
-  margin: 3rem auto;
-  padding: 0 1rem;
+  /* max-width: 1100px; */
+  /* margin: 3rem auto; */
+  width: 100%;
+  margin: 3rem 0;
+  padding: 0;
 }
 
 .portfolio h2 {


### PR DESCRIPTION
## Summary
- Allow the portfolio section to span the full width of the page
- Remove fixed width and centered margin, and adjust padding

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896596943788324a6d79cd74086fefd