### PR TITLE
Add galleries to index page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,31 @@ body {
   background-color: #ffffff;
 }
 
+.top-gallery {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+}
+
+.top-img {
+  flex: 1;
+  height: 220px;
+  object-fit: cover;
+}
+
+.bottom-gallery {
+  display: flex;
+  gap: 24px;
+  margin-top: 80px;
+}
+
+.bottom-img {
+  width: 32%;
+  height: 330px;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
 header {
   background: #f8f9fa;
   color: #111827;

--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
-  <header class="top-gallery">
-    <img src="assets/images/top-1.jpg" alt="Mosaic top image 1" />
-    <img src="assets/images/top-2.jpg" alt="Mosaic top image 2" />
-    <img src="assets/images/top-3.jpg" alt="Mosaic top image 3" />
-    <img src="assets/images/top-4.jpg" alt="Mosaic top image 4" />
-    <img src="assets/images/top-5.jpg" alt="Mosaic top image 5" />
-  </header>
+  <section class="top-gallery">
+    <img class="top-img" src="assets/images/top-1.jpg" alt="Mosaic top image 1" />
+    <img class="top-img" src="assets/images/top-2.jpg" alt="Mosaic top image 2" />
+    <img class="top-img" src="assets/images/top-3.jpg" alt="Mosaic top image 3" />
+    <img class="top-img" src="assets/images/top-4.jpg" alt="Mosaic top image 4" />
+    <img class="top-img" src="assets/images/top-5.jpg" alt="Mosaic top image 5" />
+  </section>
 
   <main>
     <h1 class="logo">Neighbor</h1>
@@ -36,9 +36,9 @@
   </main>
 
   <section class="bottom-gallery">
-    <img src="assets/images/bottom-1.jpg" alt="Bottom gallery image 1" />
-    <img src="assets/images/bottom-2.jpg" alt="Bottom gallery image 2" />
-    <img src="assets/images/bottom-3.jpg" alt="Bottom gallery image 3" />
+    <img class="bottom-img" src="assets/images/bottom-1.jpg" alt="Bottom gallery image 1" />
+    <img class="bottom-img" src="assets/images/bottom-2.jpg" alt="Bottom gallery image 2" />
+    <img class="bottom-img" src="assets/images/bottom-3.jpg" alt="Bottom gallery image 3" />
   </section>
 
   <script src="js/script.js"></script>


### PR DESCRIPTION
## Summary
- replace header gallery with section and add bottom gallery image classes
- style top and bottom galleries with flex layout and responsive images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965ddd4c0483249867848a9669acb0