### PR TITLE
Include Google fonts and link color variables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,12 +5,31 @@
   box-sizing: border-box;
 }
 
+:root {
+  --link-active: #1BC6E4;
+  --link-inactive: #888888;
+}
+
 body {
-  font-family: "Poppins", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif;
+  font-family: 'Roboto', sans-serif;
   line-height: 1.6;
   color: #111827;
   background-color: #ffffff;
+}
+
+.logo {
+  font-family: 'Pacifico', cursive;
+  font-size: 60px;
+  font-weight: 700;
+  color: #333333;
+}
+
+nav ul li {
+  color: var(--link-inactive);
+}
+
+nav ul li.active {
+  color: var(--link-active);
 }
 
 .top-gallery {

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Portfolio d'Alex Chesnay</title>
-  <!-- Import modern font for a more polished look -->
+  <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com" />
   <link
-    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Pacifico&family=Roboto:wght@400;700&display=swap"
     rel="stylesheet"
   />
   <!-- Main stylesheet -->


### PR DESCRIPTION
## Summary
- load Pacifico and Roboto from Google Fonts
- style body and logo with new fonts
- add variables for active and inactive link colors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965ee5fd788324a460f5a183dfb9d2