### PR TITLE
Add secondary navigation with styled links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,6 +75,57 @@ nav {
   display: none;
 }
 
+.secondary-nav {
+  display: flex;
+  justify-content: center;
+}
+
+.secondary-nav ul {
+  list-style: none;
+  display: flex;
+  padding: 0;
+  margin: 0;
+}
+
+.secondary-nav a {
+  font-size: 28px;
+  font-weight: 400;
+  color: var(--link-inactive);
+  text-decoration: none;
+  margin: 0 18px;
+  position: relative;
+  cursor: pointer;
+}
+
+.secondary-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--link-active);
+  transition: width 0.3s ease;
+}
+
+.secondary-nav a:hover {
+  color: var(--link-active);
+}
+
+.secondary-nav a:hover::after {
+  width: 100%;
+}
+
+.secondary-nav a.active {
+  color: var(--link-active);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.secondary-nav a.active::after {
+  width: 100%;
+}
+
 .hero {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@
 
   <main>
     <h1 class="logo">Alex Chesnay</h1>
-    <nav>
+    <nav class="secondary-nav">
       <ul>
-        <li>Featured</li>
-        <li>3D Animation</li>
-        <li>2D Animation</li>
-        <li>VFX</li>
-        <li>Virtual Reality</li>
+        <li><a href="#" class="active">Featured</a></li>
+        <li><a href="#">3D Animation</a></li>
+        <li><a href="#">2D Animation</a></li>
+        <li><a href="#">VFX</a></li>
+        <li><a href="#">Virtual Reality</a></li>
       </ul>
     </nav>
   </main>


### PR DESCRIPTION
## Summary
- Add secondary navigation menu with links under site logo
- Style secondary nav links with hover and active states

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966038c79c832493a1512de2c92020