### PR TITLE
Optimize image loading and caching

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/index.html
+++ b/index.html
@@ -26,11 +26,11 @@
     <div class="scroller" id="hero-scroller">
       <div class="scroller__content">
         <!-- move current top-gallery <img> elements here -->
-        <img class="top-img marquee-img" src="assets/images/ProjetGateauxRendu1.jpg" alt="Projet 1" />
-        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_3.jpg" alt="Projet 2" />
-        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_1.jpg" alt="Projet 3" />
-        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_2.jpg" alt="Projet 4" />
-        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" alt="Projet 5" />
+        <img class="top-img marquee-img" src="assets/images/ProjetGateauxRendu1.jpg" srcset="assets/images/ProjetGateauxRendu1.jpg" sizes="100vw" alt="Projet 1" decoding="async" />
+        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_3.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_3.jpg" sizes="100vw" alt="Projet 2" decoding="async" />
+        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="100vw" alt="Projet 3" decoding="async" />
+        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_2.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_2.jpg" sizes="100vw" alt="Projet 4" decoding="async" />
+        <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="100vw" alt="Projet 5" decoding="async" />
       </div>
     </div>
   </section>
@@ -51,15 +51,15 @@
   <!-- Galerie inférieure (BOTTOM) -->
   <div class="grid">
     <a class="card" href="work/project1.html">
-      <img class="media" src="assets/images/PAGES_0_Couverture.jpg" alt="Project 1" />
+      <img class="media" src="assets/images/PAGES_0_Couverture.jpg" srcset="assets/images/PAGES_0_Couverture.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Project 1" loading="lazy" decoding="async" />
       <div class="overlay"></div>
     </a>
     <a class="card" href="work/project2.html">
-      <img class="media" src="assets/images/project2.png" alt="Project 2" />
+      <img class="media" src="assets/images/project2.png" srcset="assets/images/project2.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Project 2" loading="lazy" decoding="async" />
       <div class="overlay"></div>
     </a>
     <a class="card" href="work/project3.html">
-      <img class="media" src="assets/images/project3.png" alt="Project 3" />
+      <img class="media" src="assets/images/project3.png" srcset="assets/images/project3.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Project 3" loading="lazy" decoding="async" />
       <div class="overlay"></div>
     </a>
   </div>

--- a/work/project1.html
+++ b/work/project1.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project1.png" alt="Project 1 hero" class="hero-media" />
+    <img src="../assets/images/project1.png" srcset="../assets/images/project1.png" sizes="100vw" alt="Project 1 hero" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -31,7 +31,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project1.png" alt="Image du projet 1" />
+      <img src="../assets/images/project1.png" srcset="../assets/images/project1.png" sizes="100vw" alt="Image du projet 1" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/project2.html
+++ b/work/project2.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project2.png" alt="Project 2 hero" class="hero-media" />
+    <img src="../assets/images/project2.png" srcset="../assets/images/project2.png" sizes="100vw" alt="Project 2 hero" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -31,7 +31,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project2.png" alt="Image du projet 2" />
+      <img src="../assets/images/project2.png" srcset="../assets/images/project2.png" sizes="100vw" alt="Image du projet 2" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/project3.html
+++ b/work/project3.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project3.png" alt="Project 3 hero" class="hero-media" />
+    <img src="../assets/images/project3.png" srcset="../assets/images/project3.png" sizes="100vw" alt="Project 3 hero" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -31,7 +31,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project3.png" alt="Image du projet 3" />
+      <img src="../assets/images/project3.png" srcset="../assets/images/project3.png" sizes="100vw" alt="Image du projet 3" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/template.html
+++ b/work/template.html
@@ -8,7 +8,7 @@
 <body>
   <header class="project-hero">
     <!-- Hero image or video -->
-    <img src="../assets/images/placeholder2.png" alt="Hero" class="hero-media" />
+    <img src="../assets/images/placeholder2.png" srcset="../assets/images/placeholder2.png" sizes="100vw" alt="Hero" class="hero-media" decoding="async" />
   </header>
 
   <main class="project-content">
@@ -37,7 +37,7 @@
 
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/placeholder3.png" alt="Gallery item" />
+      <img src="../assets/images/placeholder3.png" srcset="../assets/images/placeholder3.png" sizes="100vw" alt="Gallery item" loading="lazy" decoding="async" />
     </section>
 
     <section class="cta">


### PR DESCRIPTION
## Summary
- Add `srcset`, `sizes`, `decoding="async"`, and lazy loading to all image tags
- Cache static assets for a year via `_headers`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968deea38c832495d37a4dcedcdde2