### PR TITLE
Add Netlify redirect and sitemap

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+https://alexchesnay.netlify.app/* https://alexchesnay.com/:splat 301!

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://alexchesnay.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://alexchesnay.com/</loc>
+  </url>
+  <url>
+    <loc>https://alexchesnay.com/work/project1.html</loc>
+  </url>
+  <url>
+    <loc>https://alexchesnay.com/work/project2.html</loc>
+  </url>
+  <url>
+    <loc>https://alexchesnay.com/work/project3.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add Netlify `_redirects` file to forward the Netlify subdomain to alexchesnay.com with a 301 redirect
- generate `robots.txt` with sitemap reference
- generate `sitemap.xml` covering the index and work pages

## Testing
- `npx -y htmlhint index.html work/project1.html work/project2.html work/project3.html` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689694f712d08324ae25b02e69599e22