### PR TITLE
feat: add dynamic project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Alex-Chesnay
+
+## Ajouter un projet
+
+1. Ajouter les images du projet dans le dossier `assets/images`.
+2. Éditer `data/projects.json` et ajouter un objet contenant les champs :
+   - `slug`
+   - `title`
+   - `images` (tableau des chemins d'images)
+   - `video` (URL de la vidéo intégrée)
+   - `description`
+   - `category`
+3. La page du projet est générée automatiquement et l'entrée apparaît dans la galerie `/projects`.
+4. Le bouton « Retour à la galerie » permet de revenir à la liste des projets.

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,0 +1,24 @@
+[
+  {
+    "slug": "alpha",
+    "title": "Projet Alpha",
+    "images": [
+      "/assets/images/project1.png",
+      "/assets/images/project2.png"
+    ],
+    "video": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    "description": "Description du projet Alpha.",
+    "category": "Demo"
+  },
+  {
+    "slug": "beta",
+    "title": "Projet Beta",
+    "images": [
+      "/assets/images/project3.png",
+      "/assets/images/project4.png"
+    ],
+    "video": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+    "description": "Description du projet Beta.",
+    "category": "Demo"
+  }
+]

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -1,11 +1,47 @@
-import { useRouter } from 'next/router';
+import fs from 'fs';
+import path from 'path';
+import Image from 'next/image';
+import Link from 'next/link';
 
-export default function Project() {
-  const { query } = useRouter();
+export default function Project({ project }) {
   return (
     <main>
-      <h1>Projet: {query.slug}</h1>
-      <p>Contenu du projet {query.slug}.</p>
+      <h1>{project.title}</h1>
+      <div>
+        {project.images.map((img, idx) => (
+          <Image
+            key={idx}
+            src={img}
+            alt={`${project.title} image ${idx + 1}`}
+            width={800}
+            height={600}
+          />
+        ))}
+      </div>
+      <div>
+        <iframe
+          src={project.video}
+          title={project.title}
+          allowFullScreen
+          style={{ width: '100%', height: '400px' }}
+        />
+      </div>
+      <p>{project.description}</p>
+      <Link href="/projects"><button>Retour à la galerie</button></Link>
     </main>
   );
+}
+
+export async function getStaticPaths() {
+  const filePath = path.join(process.cwd(), 'data', 'projects.json');
+  const projects = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const paths = projects.map((p) => ({ params: { slug: p.slug } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const filePath = path.join(process.cwd(), 'data', 'projects.json');
+  const projects = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const project = projects.find((p) => p.slug === params.slug);
+  return { props: { project } };
 }

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -1,16 +1,13 @@
 import Link from 'next/link';
+import fs from 'fs';
+import path from 'path';
 
-const projects = [
-  { slug: 'alpha', title: 'Projet Alpha' },
-  { slug: 'beta', title: 'Projet Beta' }
-];
-
-export default function Projects() {
+export default function Projects({ projects }) {
   return (
     <main>
       <h1>Galerie</h1>
       <ul>
-        {projects.map(p => (
+        {projects.map((p) => (
           <li key={p.slug}>
             <Link href={`/projects/${p.slug}`}>{p.title}</Link>
           </li>
@@ -18,4 +15,10 @@ export default function Projects() {
       </ul>
     </main>
   );
+}
+
+export async function getStaticProps() {
+  const filePath = path.join(process.cwd(), 'data', 'projects.json');
+  const projects = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return { props: { projects } };
 }


### PR DESCRIPTION
## Summary
- add `data/projects.json` with project metadata
- render project gallery from JSON and dynamic project pages with images and video
- document how to add projects

## Testing
- `npm test`
- `npm run lint` *(fails to finish: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68969f8e8fc88324b5effbda107b999d