### PR TITLE
feat: improve SEO metadata and sitemap generation

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,4 @@
+export default {
+  siteUrl: 'https://alex-chesnay.com',
+  generateRobotsTxt: true,
+};

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "echo \"No tests specified\" && exit 0",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "framer-motion": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"
+  },
+  "devDependencies": {
+    "next-sitemap": "latest"
   }
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,8 +1,33 @@
+import Head from 'next/head';
+
+const siteUrl = 'https://alex-chesnay.com';
+
 export default function About() {
+  const title = 'À propos - Alex Chesnay';
+  const description = 'Quelques informations sur moi.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/about`;
+
   return (
-    <main>
-      <h1>À propos</h1>
-      <p>Quelques informations sur moi.</p>
-    </main>
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main>
+        <h1>À propos</h1>
+        <p>Quelques informations sur moi.</p>
+      </main>
+    </>
   );
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,8 +1,33 @@
+import Head from 'next/head';
+
+const siteUrl = 'https://alex-chesnay.com';
+
 export default function Contact() {
+  const title = 'Contact - Alex Chesnay';
+  const description = 'Contactez-moi via email.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/contact`;
+
   return (
-    <main>
-      <h1>Contact</h1>
-      <p>Contactez-moi via email.</p>
-    </main>
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main>
+        <h1>Contact</h1>
+        <p>Contactez-moi via email.</p>
+      </main>
+    </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,14 +1,38 @@
+import Head from 'next/head';
 import HeroHeader from '../components/HeroHeader';
 import theme from '../styles/theme';
 
+const siteUrl = 'https://alex-chesnay.com';
+
 export default function Home() {
+  const title = 'Accueil - Alex Chesnay';
+  const description = 'Bienvenue sur mon portfolio.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/`;
+
   return (
-    <main>
-      <HeroHeader />
-      <section style={{ padding: theme.spacing.lg }}>
-        <h1>Accueil</h1>
-        <p>Bienvenue sur mon portfolio.</p>
-      </section>
-    </main>
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main>
+        <HeroHeader />
+        <section style={{ padding: theme.spacing.lg }}>
+          <h1>Accueil</h1>
+          <p>Bienvenue sur mon portfolio.</p>
+        </section>
+      </main>
+    </>
   );
 }

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -1,34 +1,71 @@
+import Head from 'next/head';
 import fs from 'fs';
 import path from 'path';
 import Link from 'next/link';
 
+const siteUrl = 'https://alex-chesnay.com';
+
 export default function Project({ project }) {
+  const url = `${siteUrl}/projects/${project.slug}`;
+  const image = `${siteUrl}${project.images[0]}`;
+  const title = `${project.title} - Projet - Alex Chesnay`;
+  const description = project.description;
+
   return (
-    <main>
-      <h1>{project.title}</h1>
-      <div className="responsive-grid">
-        {project.images.map((img, idx) => (
-          <img
-            key={idx}
-            src={img}
-            srcSet={`${img} 480w, ${img} 800w`}
-            sizes="(max-width: 600px) 100vw, 50vw"
-            alt={`${project.title} image ${idx + 1}`}
-            loading="lazy"
-            decoding="async"
-          />
-        ))}
-      </div>
-      <div className="video-wrapper">
-        <iframe
-          src={project.video}
-          title={project.title}
-          allowFullScreen
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'CreativeWork',
+              name: project.title,
+              description: project.description,
+              image: project.images.map((img) => `${siteUrl}${img}`),
+              url,
+            }),
+          }}
         />
-      </div>
-      <p>{project.description}</p>
-      <Link href="/projects"><button>Retour à la galerie</button></Link>
-    </main>
+      </Head>
+      <main>
+        <h1>{project.title}</h1>
+        <div className="responsive-grid">
+          {project.images.map((img, idx) => (
+            <img
+              key={idx}
+              src={img}
+              srcSet={`${img} 480w, ${img} 800w`}
+              sizes="(max-width: 600px) 100vw, 50vw"
+              alt={`${project.title} illustration ${idx + 1}`}
+              loading="lazy"
+              decoding="async"
+            />
+          ))}
+        </div>
+        <div className="video-wrapper">
+          <iframe
+            src={project.video}
+            title={project.title}
+            allowFullScreen
+          />
+        </div>
+        <p>{project.description}</p>
+        <Link href="/projects"><button>Retour à la galerie</button></Link>
+      </main>
+    </>
   );
 }
 

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import Link from 'next/link';
 import fs from 'fs';
 import path from 'path';
@@ -12,53 +13,76 @@ const cardVariants = {
   exit: { opacity: 0, y: -20 }
 };
 
+const siteUrl = 'https://alex-chesnay.com';
+
 export default function Projects({ projects }) {
   const [selectedCategory, setSelectedCategory] = useState('3D');
   const filteredProjects = projects.filter(
     (p) => p.category === selectedCategory
   );
 
+  const title = 'Projets - Alex Chesnay';
+  const description = 'Galerie de mes projets.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/projects`;
+
   return (
-    <main style={{ padding: theme.spacing.lg }}>
-      <h1>Galerie</h1>
-      <FilterBar
-        selectedCategory={selectedCategory}
-        onSelect={setSelectedCategory}
-      />
-      <motion.ul
-        layout
-        className="responsive-grid"
-        style={{
-          listStyle: 'none',
-          padding: 0,
-          margin: `${theme.spacing.lg} 0`,
-          gap: theme.spacing.md
-        }}
-      >
-        <AnimatePresence>
-          {filteredProjects.map((p) => (
-            <motion.li
-              key={p.slug}
-              layout
-              variants={cardVariants}
-              initial="hidden"
-              animate="visible"
-              exit="exit"
-              whileHover={{ scale: 1.05 }}
-              transition={{ duration: 0.3 }}
-              style={{
-                background: theme.colors.background,
-                padding: theme.spacing.md,
-                borderRadius: '8px',
-                boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
-              }}
-            >
-              <Link href={`/projects/${p.slug}`}>{p.title}</Link>
-            </motion.li>
-          ))}
-        </AnimatePresence>
-      </motion.ul>
-    </main>
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main style={{ padding: theme.spacing.lg }}>
+        <h1>Galerie</h1>
+        <FilterBar
+          selectedCategory={selectedCategory}
+          onSelect={setSelectedCategory}
+        />
+        <motion.ul
+          layout
+          className="responsive-grid"
+          style={{
+            listStyle: 'none',
+            padding: 0,
+            margin: `${theme.spacing.lg} 0`,
+            gap: theme.spacing.md
+          }}
+        >
+          <AnimatePresence>
+            {filteredProjects.map((p) => (
+              <motion.li
+                key={p.slug}
+                layout
+                variants={cardVariants}
+                initial="hidden"
+                animate="visible"
+                exit="exit"
+                whileHover={{ scale: 1.05 }}
+                transition={{ duration: 0.3 }}
+                style={{
+                  background: theme.colors.background,
+                  padding: theme.spacing.md,
+                  borderRadius: '8px',
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
+                }}
+              >
+                <Link href={`/projects/${p.slug}`}>{p.title}</Link>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </motion.ul>
+      </main>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add meta, Open Graph, Twitter, and canonical tags to all pages
- generate sitemap.xml and robots.txt with next-sitemap
- provide structured data and descriptive alt text for project pages

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6896afcd2f7c8324b951542fb92385a6