### PR TITLE
docs: ajouter guide développeur et configuration Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # Alex-Chesnay
 
-## Ajouter un projet
+Portfolio réalisé avec Next.js.
 
+## Structure du projet
+- `assets/` – ressources statiques (images)
+- `components/` – composants React
+- `pages/` – routes Next.js
+- `styles/` – styles globaux et thème
+- `private/projects.json` – données des projets
+- `_headers` – configuration des en-têtes HTTP et du cache
+- `_redirects` – règles de redirection
+- `netlify.toml` – configuration Netlify
+
+## Ajouter un projet
 1. Ajouter les images du projet dans le dossier `assets/images`.
-2. Éditer `private/projects.json` et ajouter un objet contenant les champs :
+2. Éditer `private/projects.json` et ajouter un objet contenant :
    - `slug`
    - `title`
    - `images` (tableau des chemins d'images)
@@ -11,4 +22,31 @@
    - `description`
    - `category`
 3. La page du projet est générée automatiquement et l'entrée apparaît dans la galerie `/projects`.
-4. Le bouton « Retour à la galerie » permet de revenir à la liste des projets.
+4. *(Optionnel)* Lancer `npm run build` pour vérifier la génération.
+5. Le bouton « Retour à la galerie » permet de revenir à la liste des projets.
+
+## Build
+La commande `npm run build` compile le site dans le dossier `.next`.
+
+## Déploiement & configuration
+- Le déploiement continu est géré par Netlify via `netlify.toml`.
+- Netlify active automatiquement HTTPS et une redirection HTTP→HTTPS est définie.
+- Les en-têtes de sécurité (`Referrer-Policy`, `Content-Security-Policy`) et la mise en cache longue durée des assets (`Cache-Control: public, max-age=31536000, immutable` pour `/assets/*`) sont définis dans `_headers`.
+
+## Guide rapide pour les développeurs
+
+### Installation
+```bash
+npm install
+```
+
+### Scripts
+- `npm run dev` : serveur de développement
+- `npm run build` : build de production
+- `npm start` : exécute le build
+- `npm run lint` : analyse du code
+
+### Conventions
+- Messages de commit clairs en style impératif
+- Exécuter `npm run lint` avant de pousser
+- Respecter la structure Next.js (composants en PascalCase, etc.)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+[[redirects]]
+  from = "http://*"
+  to = "https://:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
## Summary
- documenter la structure du projet, l'ajout d'un projet et les commandes de build
- décrire l'activation HTTPS, le cache et les headers dans la doc
- configurer le déploiement Netlify via `netlify.toml`

## Testing
- `npm test`
- `npm run lint` *(échoue: How would you like to configure ESLint?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896b1dbbc048324b6f56c9873472429