### PR TITLE
Add services and legal pages

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -18,8 +18,10 @@ export default function Header() {
     >
       <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
       <Link href="/projects" className={asPath.startsWith('/projects') ? styles.active : ''}>Projets</Link>
-      <Link href="/about" className={asPath === '/about' ? styles.active : ''}>À propos</Link>
+      <Link href="/services" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
+      <Link href="/a-propos" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
       <Link href="/contact" className={asPath === '/contact' ? styles.active : ''}>Contact</Link>
+      <Link href="/mentions-legales" className={asPath === '/mentions-legales' ? styles.active : ''}>Mentions légales</Link>
     </nav>
   );
 }

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -1,0 +1,33 @@
+import Head from 'next/head';
+
+const siteUrl = 'https://alex-chesnay.com';
+
+export default function APropos() {
+  const title = 'À propos - Alex Chesnay';
+  const description = 'Quelques informations sur moi.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/a-propos`;
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main>
+        <h1>À propos</h1>
+        <p>Quelques informations sur moi.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -1,0 +1,33 @@
+import Head from 'next/head';
+
+const siteUrl = 'https://alex-chesnay.com';
+
+export default function MentionsLegales() {
+  const title = 'Mentions légales - Alex Chesnay';
+  const description = 'Informations légales du site.';
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/mentions-legales`;
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <main>
+        <h1>Mentions légales</h1>
+        <p>Informations légales du site.</p>
+      </main>
+    </>
+  );
+}

--- a/pages/services/index.js
+++ b/pages/services/index.js
@@ -2,11 +2,11 @@ import Head from 'next/head';
 
 const siteUrl = 'https://alex-chesnay.com';
 
-export default function About() {
-  const title = 'À propos - Alex Chesnay';
-  const description = 'Quelques informations sur moi.';
+export default function Services() {
+  const title = 'Services - Alex Chesnay';
+  const description = 'Description des services proposés.';
   const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
-  const url = `${siteUrl}/about`;
+  const url = `${siteUrl}/services`;
 
   return (
     <>
@@ -25,8 +25,8 @@ export default function About() {
         <link rel="canonical" href={url} />
       </Head>
       <main>
-        <h1>À propos</h1>
-        <p>Quelques informations sur moi.</p>
+        <h1>Services</h1>
+        <p>Description des services proposés.</p>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- rename about page to a-propos and adjust metadata
- add services and mentions-legales pages with placeholder content and SEO tags
- expand header navigation to include services, a-propos, and legal links

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896b7d0c8cc83249a184e61e2fa44b9