### PR TITLE
Add contact form with reCAPTCHA verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "framer-motion": "latest",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-google-recaptcha": "latest",
+    "nodemailer": "latest",
+    "validator": "latest"
   },
   "devDependencies": {
     "next-sitemap": "latest"

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,0 +1,60 @@
+import nodemailer from 'nodemailer';
+import validator from 'validator';
+
+async function verifyRecaptcha(token) {
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  const res = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `secret=${encodeURIComponent(secret)}&response=${encodeURIComponent(token)}`,
+  });
+  return res.json();
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { name, email, message, token } = req.body;
+
+  if (!name || !email || !message || !token) {
+    return res.status(400).json({ error: 'Tous les champs sont requis.' });
+  }
+
+  if (!validator.isEmail(email)) {
+    return res.status(400).json({ error: "Email invalide." });
+  }
+
+  const cleanName = validator.escape(name.trim());
+  const cleanEmail = validator.normalizeEmail(email);
+  const cleanMessage = validator.escape(message.trim());
+
+  const recap = await verifyRecaptcha(token);
+  if (!recap.success) {
+    return res.status(400).json({ error: 'Échec de la vérification reCAPTCHA.' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || cleanEmail,
+      to: process.env.SMTP_TO,
+      subject: 'Nouveau message de contact',
+      text: `Nom: ${cleanName}\nEmail: ${cleanEmail}\nMessage: ${cleanMessage}`,
+    });
+
+    return res.status(200).json({ message: 'Message envoyé.' });
+  } catch (err) {
+    return res.status(500).json({ error: "Échec de l'envoi du message." });
+  }
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,4 +1,6 @@
 import Head from 'next/head';
+import { useState, useRef } from 'react';
+import ReCAPTCHA from 'react-google-recaptcha';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -7,6 +9,37 @@ export default function Contact() {
   const description = 'Contactez-moi via email.';
   const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
   const url = `${siteUrl}/contact`;
+
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [status, setStatus] = useState(null);
+  const recaptchaRef = useRef(null);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      const token = await recaptchaRef.current.executeAsync();
+      recaptchaRef.current.reset();
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, token }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus({ type: 'success', message: 'Message envoyé !' });
+        setForm({ name: '', email: '', message: '' });
+      } else {
+        setStatus({ type: 'error', message: data.error || 'Une erreur est survenue' });
+      }
+    } catch (err) {
+      setStatus({ type: 'error', message: 'Une erreur est survenue' });
+    }
+  };
 
   return (
     <>
@@ -26,7 +59,50 @@ export default function Contact() {
       </Head>
       <main>
         <h1>Contact</h1>
-        <p>Contactez-moi via email.</p>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="name">Nom</label>
+            <input
+              id="name"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div>
+            <label htmlFor="message">Message</label>
+            <textarea
+              id="message"
+              name="message"
+              value={form.message}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <button type="submit">Envoyer</button>
+          <ReCAPTCHA
+            ref={recaptchaRef}
+            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+            size="invisible"
+          />
+        </form>
+        {status && (
+          <p className={status.type === 'success' ? 'success' : 'error'}>
+            {status.message}
+          </p>
+        )}
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- Add contact form with name, email and message fields and client-side ReCAPTCHA token generation
- Create API route that sanitizes input, verifies ReCAPTCHA and sends email via Nodemailer
- Include dependencies for Nodemailer, validation and react-google-recaptcha

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896b941b2c08324a01da0e5b890fb0b