### PR TITLE
feat: add local font support and preload fonts

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,46 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            rel="preload"
+            href="/fonts/Raleway-400.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="/fonts/Raleway-700.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="/fonts/PlayfairDisplay-400.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="/fonts/PlayfairDisplay-700.woff2"
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/public/fonts/PlayfairDisplay-400.woff2
+++ b/public/fonts/PlayfairDisplay-400.woff2
@@ -1,0 +1,1 @@
+placeholder

--- a/public/fonts/PlayfairDisplay-700.woff2
+++ b/public/fonts/PlayfairDisplay-700.woff2
@@ -1,0 +1,1 @@
+placeholder

--- a/public/fonts/Raleway-400.woff2
+++ b/public/fonts/Raleway-400.woff2
@@ -1,0 +1,1 @@
+placeholder

--- a/public/fonts/Raleway-700.woff2
+++ b/public/fonts/Raleway-700.woff2
@@ -1,0 +1,1 @@
+placeholder

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,35 @@
+@font-face {
+  font-family: 'Raleway';
+  src: url('/fonts/Raleway-400.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Raleway';
+  src: url('/fonts/Raleway-700.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Playfair Display';
+  src: url('/fonts/PlayfairDisplay-400.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Playfair Display';
+  src: url('/fonts/PlayfairDisplay-700.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -6,8 +6,8 @@ const theme = {
     accent: '#FF6347'
   },
   fonts: {
-    heading: '"Helvetica Neue", sans-serif',
-    body: 'Arial, sans-serif'
+    heading: "'Playfair Display', serif",
+    body: "'Raleway', sans-serif"
   },
   spacing: {
     xs: '4px',


### PR DESCRIPTION
## Summary
- add placeholder Raleway and Playfair Display font files under `public/fonts`
- define `@font-face` rules in `styles/globals.css`
- update theme to reference new font families
- preload fonts via custom `_document.js`

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896bb6e98e483249f9b4cd21317a33d