### PR TITLE
Add security headers and block external hotlinking

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,7 @@
 /*
   Referrer-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; img-src 'self' data:;
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com;
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,8 @@
 /private/* /404.html 404
+
+# Allow asset requests from own domains
+/assets/* /assets/:splat 200! Referer=https://alexchesnay.com/*
+/assets/* /assets/:splat 200! Referer=https://alex-chesnay.com/*
+
+# Block external hotlinking
+/assets/* 403


### PR DESCRIPTION
## Summary
- add HSTS header to enforce HTTPS and update Content Security Policy
- block hotlinking by rejecting asset requests with external referers

## Testing
- `npm test`
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896c342eb248324907e7afd6eaff16d