### PR TITLE
Add security audit workflow and form logging

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,17 @@
+name: Monthly security audit
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install --production
+      - run: npm audit --production

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .next/
 package-lock.json
+private/contact-submissions.log

--- a/_redirects
+++ b/_redirects
@@ -1,8 +1,8 @@
 /private/* /404.html 404
 
-# Allow asset requests from own domains
-/assets/* /assets/:splat 200! Referer=https://alexchesnay.com/*
-/assets/* /assets/:splat 200! Referer=https://alex-chesnay.com/*
+# Allow image requests from own domains
+/assets/images/* /assets/images/:splat 200! Referer=https://alexchesnay.com/*
+/assets/images/* /assets/images/:splat 200! Referer=https://alex-chesnay.com/*
 
 # Block external hotlinking
-/assets/* 403
+/assets/images/* 403

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -1,5 +1,7 @@
 import nodemailer from 'nodemailer';
 import validator from 'validator';
+import fs from 'fs';
+import path from 'path';
 
 async function verifyRecaptcha(token) {
   const secret = process.env.RECAPTCHA_SECRET_KEY;
@@ -26,16 +28,26 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Email invalide." });
   }
 
-  const cleanName = validator.escape(name.trim());
-  const cleanEmail = validator.normalizeEmail(email);
-  const cleanMessage = validator.escape(message.trim());
+    const cleanName = validator.escape(name.trim());
+    const cleanEmail = validator.normalizeEmail(email);
+    const cleanMessage = validator.escape(message.trim());
 
-  const recap = await verifyRecaptcha(token);
-  if (!recap.success) {
+    const recap = await verifyRecaptcha(token);
+    if (!recap.success) {
     return res.status(400).json({ error: 'Échec de la vérification reCAPTCHA.' });
-  }
+    }
 
-  try {
+    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const suspicious = /https?:\/\//i.test(cleanMessage);
+    const logLine = `${new Date().toISOString()} | IP: ${ip} | Suspicious: ${suspicious} | Name: ${cleanName} | Email: ${cleanEmail} | Message: ${cleanMessage}\n`;
+    const logFile = path.join(process.cwd(), 'private', 'contact-submissions.log');
+    try {
+    await fs.promises.appendFile(logFile, logLine);
+    } catch (err) {
+    console.error('Failed to log submission', err);
+    }
+
+    try {
     const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: Number(process.env.SMTP_PORT) || 587,
@@ -54,7 +66,7 @@ export default async function handler(req, res) {
     });
 
     return res.status(200).json({ message: 'Message envoyé.' });
-  } catch (err) {
+    } catch (err) {
     return res.status(500).json({ error: "Échec de l'envoi du message." });
+    }
   }
-}


### PR DESCRIPTION
## Summary
- restrict direct image access to valid referrers
- schedule monthly npm security audit
- log contact form submissions for suspicious activity

## Testing
- `npm test`
- `npm audit --production` *(fails: audit endpoint returned 403)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6896c539aaa883248b596a76db88f872