### PR TITLE
Add privacy policy link and projects dropdown

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -1,10 +1,14 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import styles from './Header.module.css';
 import theme from '../../styles/theme';
+import projects from '../../private/projects.json' assert { type: 'json' };
 
 export default function Header() {
   const { asPath } = useRouter();
+  const [projectsOpen, setProjectsOpen] = useState(asPath.startsWith('/projects'));
+
   return (
     <nav
       className={styles.nav}
@@ -17,11 +21,42 @@ export default function Header() {
       }}
     >
       <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
-      <Link href="/projects" className={asPath.startsWith('/projects') ? styles.active : ''}>Projets</Link>
+      <details
+        className={styles.dropdown}
+        open={projectsOpen}
+        onToggle={(e) => setProjectsOpen(e.target.open)}
+      >
+        <summary
+          aria-haspopup="menu"
+          aria-expanded={projectsOpen}
+          className={asPath.startsWith('/projects') ? styles.active : ''}
+        >
+          Projets
+        </summary>
+        <ul className={styles.dropdownMenu} role="menu">
+          {projects.map((project) => (
+            <li key={project.slug} role="none">
+              <Link
+                href={`/projects/${project.slug}`}
+                className={asPath === `/projects/${project.slug}` ? styles.active : ''}
+                role="menuitem"
+              >
+                {project.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </details>
       <Link href="/services" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
       <Link href="/a-propos" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
       <Link href="/contact" className={asPath === '/contact' ? styles.active : ''}>Contact</Link>
       <Link href="/mentions-legales" className={asPath === '/mentions-legales' ? styles.active : ''}>Mentions légales</Link>
+      <Link
+        href="/politique-de-confidentialite"
+        className={asPath === '/politique-de-confidentialite' ? styles.active : ''}
+      >
+        Politique de confidentialité
+      </Link>
     </nav>
   );
 }

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -7,12 +7,40 @@
   flex-wrap: wrap;
 }
 
-.nav a {
+.nav a,
+.nav summary {
   text-decoration: none;
   padding: 0.75rem 1rem;
   min-height: 44px;
   display: flex;
   align-items: center;
+  cursor: pointer;
+}
+
+.nav summary::-webkit-details-marker {
+  display: none;
+}
+
+.dropdown {
+  position: relative;
+}
+
+.dropdownMenu {
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: inherit;
+  border: 1px solid currentColor;
+  z-index: 10;
+}
+
+.dropdown[open] .dropdownMenu {
+  display: flex;
 }
 
 .active {


### PR DESCRIPTION
## Summary
- add privacy policy link in header navigation
- replace Projects link with accessible dropdown menu sourced from private/projects.json
- style header for dropdown and keyboard navigation

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897223f37d0832488f0b75341fa6091