### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/components/CookieBanner.js
+++ b/components/CookieBanner.js
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+
+// Load third-party scripts (e.g., analytics) after consent
+function loadThirdPartyScripts() {
+  if (typeof window === 'undefined' || window.thirdPartyScriptsLoaded) return;
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  if (gaId) {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){window.dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', gaId);
+  }
+  window.thirdPartyScriptsLoaded = true;
+}
+
+export default function CookieBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const consent = localStorage.getItem('cookieConsent');
+    if (consent === 'accepted') {
+      loadThirdPartyScripts();
+    } else if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('cookieConsent', 'accepted');
+    setVisible(false);
+    loadThirdPartyScripts();
+  };
+
+  const refuse = () => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('cookieConsent', 'refused');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="cookie-banner">
+      <p>Ce site utilise des cookies pour améliorer votre expérience.</p>
+      <div className="actions">
+        <button onClick={accept}>Accepter</button>
+        <button onClick={refuse}>Refuser</button>
+      </div>
+      <style jsx>{`
+        .cookie-banner {
+          position: fixed;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: rgba(0,0,0,0.8);
+          color: #fff;
+          padding: 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          align-items: center;
+          z-index: 1000;
+        }
+        .actions button {
+          margin: 0 0.5rem;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@ import '../styles/globals.css';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import Header from '../components/Layout/Header';
+import CookieBanner from '../components/CookieBanner';
 import theme from '../styles/theme';
 
 export default function MyApp({ Component, pageProps }) {
@@ -16,6 +17,7 @@ export default function MyApp({ Component, pageProps }) {
       }}
     >
       <Header />
+      <CookieBanner />
       <AnimatePresence mode="wait" initial={false}>
         <motion.div
           key={router.asPath}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import ReCAPTCHA from 'react-google-recaptcha';
 
 const siteUrl = 'https://alex-chesnay.com';
@@ -13,6 +13,14 @@ export default function Contact() {
   const [form, setForm] = useState({ name: '', email: '', message: '' });
   const [status, setStatus] = useState(null);
   const recaptchaRef = useRef(null);
+  const [hasConsent, setHasConsent] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const consent = localStorage.getItem('cookieConsent');
+      setHasConsent(consent === 'accepted');
+    }
+  }, []);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -21,6 +29,10 @@ export default function Contact() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setStatus(null);
+    if (!hasConsent) {
+      setStatus({ type: 'error', message: 'Veuillez accepter les cookies pour envoyer le formulaire.' });
+      return;
+    }
     try {
       const token = await recaptchaRef.current.executeAsync();
       recaptchaRef.current.reset();
@@ -92,11 +104,13 @@ export default function Contact() {
             />
           </div>
           <button type="submit">Envoyer</button>
-          <ReCAPTCHA
-            ref={recaptchaRef}
-            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
-            size="invisible"
-          />
+          {hasConsent && (
+            <ReCAPTCHA
+              ref={recaptchaRef}
+              sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
+              size="invisible"
+            />
+          )}
         </form>
         {status && (
           <p className={status.type === 'success' ? 'success' : 'error'}>


### PR DESCRIPTION
## Summary
- add cookie banner component with accept/refuse actions
- display cookie banner on all pages and load third-party scripts only after consent
- ensure ReCAPTCHA loads only after consent on the contact form

## Testing
- `npm test`
- `npm run lint` *(fails: ? How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68972490946883248d6291e5d24164fe