### PR TITLE
docs: add security plan and backup script

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Plan de sécurité et de maintenance
+
+## HTTPS, TLS 1.3 et HSTS
+- Utiliser un fournisseur comme Netlify ou Cloudflare pour servir le site en HTTPS.
+- Activer la prise en charge de TLS 1.3 dans le tableau de bord du fournisseur.
+- L'en‑tête `Strict-Transport-Security` est défini dans le fichier [`_headers`](./_headers) pour forcer les navigateurs à rester en HTTPS.
+
+## Pare-feu applicatif (WAF) et protection anti-DDoS
+- Activer un WAF et le mode anti-DDoS du fournisseur (ex. Cloudflare, AWS Shield).
+- Configurer les règles pour bloquer les attaques courantes et limiter le trafic abusif.
+
+## Sauvegardes quotidiennes chiffrées
+- Le script [`scripts/backup.sh`](./scripts/backup.sh) crée une archive du dépôt, la chiffre en AES‑256 puis l'envoie sur un serveur externe.
+- Exemple de planification quotidienne via cron :
+  ```
+  0 2 * * * BACKUP_PASS=motdepasse /chemin/vers/scripts/backup.sh
+  ```
+  où `BACKUP_PASS` définit la clé de chiffrement.
+
+## Monitoring et maintenance trimestrielle
+- Mettre en place un outil de supervision d'uptime (UptimeRobot, Uptime Kuma…) et un système de détection d'intrusion (Wazuh, Fail2ban…).
+- Plan de maintenance tous les trimestres :
+  - Mettre à jour les dépendances et appliquer les correctifs de sécurité.
+  - Vérifier les journaux de monitoring et d'intrusion.
+  - Tester la restauration des sauvegardes.
+  - Lancer un scan de vulnérabilité.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Encrypt and transfer a backup of the repository to a remote server.
+# Usage: BACKUP_PASS=yourpassword ./backup.sh
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DATE="$(date +%F)"
+ARCHIVE="/tmp/alex-chesnay-$DATE.tar.gz"
+ENCRYPTED="${ARCHIVE}.enc"
+REMOTE_USER="backup"
+REMOTE_HOST="backup.example.com"
+REMOTE_DIR="/var/backups/alex-chesnay"
+
+# Create compressed archive
+ tar -czf "$ARCHIVE" -C "$REPO_DIR" .
+
+# Encrypt archive using AES-256
+ openssl enc -aes-256-cbc -pbkdf2 -salt -pass env:BACKUP_PASS -in "$ARCHIVE" -out "$ENCRYPTED"
+ rm "$ARCHIVE"
+
+# Transfer to remote server (requires SSH key or passwordless setup)
+ scp "$ENCRYPTED" "$REMOTE_USER@$REMOTE_HOST:$REMOTE_DIR/"
+ rm "$ENCRYPTED"


### PR DESCRIPTION
## Summary
- document HTTPS/TLS, HSTS, WAF, backup, and monitoring procedures
- add AES-256 encrypted backup script

## Testing
- `bash -n scripts/backup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68972d9de9408324b4f50663d52aebd3