### PR TITLE
feat: add preloader and scroll animations

### DIFF
--- a/components/Preloader.js
+++ b/components/Preloader.js
@@ -1,0 +1,36 @@
+import { motion } from 'framer-motion';
+
+export default function Preloader() {
+  const spinTransition = { repeat: Infinity, ease: 'linear', duration: 1 };
+  return (
+    <motion.div
+      initial={{ opacity: 1 }}
+      animate={{ opacity: 0 }}
+      transition={{ duration: 0.5, delay: 0.5 }}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#fff',
+        zIndex: 9999,
+      }}
+    >
+      <motion.div
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: '50%',
+          border: '4px solid #000',
+          borderTopColor: 'transparent',
+        }}
+        animate={{ rotate: 360 }}
+        transition={spinTransition}
+      />
+    </motion.div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,34 @@
 import '../styles/globals.css';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import Header from '../components/Layout/Header';
 import CookieBanner from '../components/CookieBanner';
+import Preloader from '../components/Preloader';
 import theme from '../styles/theme';
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const handleLoad = () => {
+      setTimeout(() => setLoading(false), 500);
+    };
+    if (typeof window !== 'undefined') {
+      if (document.readyState === 'complete') {
+        handleLoad();
+      } else {
+        window.addEventListener('load', handleLoad);
+        return () => window.removeEventListener('load', handleLoad);
+      }
+    }
+  }, []);
+
+  if (loading) {
+    return <Preloader />;
+  }
+
   return (
     <div
       style={{

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -24,10 +25,15 @@ export default function APropos() {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+      <motion.main
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>À propos</h1>
         <p>Quelques informations sur moi.</p>
-      </main>
+      </motion.main>
     </>
   );
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { useState, useRef, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import ReCAPTCHA from 'react-google-recaptcha';
 import { generateSecret, generateToken } from '../lib/csrf.js';
 
@@ -80,7 +81,12 @@ export default function Contact({ csrfToken }) {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+      <motion.main
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>Contact</h1>
         <form onSubmit={handleSubmit}>
           <div>
@@ -129,7 +135,7 @@ export default function Contact({ csrfToken }) {
             {status.message}
           </p>
         )}
-      </main>
+      </motion.main>
     </>
   );
 }

--- a/pages/credits.js
+++ b/pages/credits.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -42,7 +43,12 @@ export default function Credits() {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+      <motion.main
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>Crédits</h1>
         <p>Liste des images utilisées sur ce site avec leur source et licence.</p>
         <ul>
@@ -52,7 +58,7 @@ export default function Credits() {
             </li>
           ))}
         </ul>
-      </main>
+      </motion.main>
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import HeroHeader from '../components/HeroHeader';
 import theme from '../styles/theme';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -28,10 +29,16 @@ export default function Home() {
       </Head>
       <main>
         <HeroHeader />
-        <section style={{ padding: theme.spacing.lg }}>
+        <motion.section
+          style={{ padding: theme.spacing.lg }}
+          initial={{ opacity: 0, y: 40 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
           <h1>Accueil</h1>
           <p>Bienvenue sur mon portfolio.</p>
-        </section>
+        </motion.section>
       </main>
     </>
   );

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -24,7 +25,12 @@ export default function MentionsLegales() {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+        <motion.main
+          initial={{ opacity: 0, y: 40 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
         <h1>Mentions légales</h1>
         <section>
           <h2>Éditeur du site</h2>
@@ -59,7 +65,7 @@ export default function MentionsLegales() {
             </a>
           </p>
         </section>
-      </main>
+        </motion.main>
     </>
   );
 }

--- a/pages/politique-de-confidentialite.js
+++ b/pages/politique-de-confidentialite.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -24,7 +25,12 @@ export default function PolitiqueDeConfidentialite() {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+      <motion.main
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>Politique de confidentialité</h1>
         <section>
           <h2>Données collectées</h2>
@@ -68,7 +74,7 @@ export default function PolitiqueDeConfidentialite() {
             .
           </p>
         </section>
-      </main>
+      </motion.main>
     </>
   );
 }

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -42,7 +42,13 @@ export default function Projects({ projects }) {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main style={{ padding: theme.spacing.lg }}>
+      <motion.main
+        style={{ padding: theme.spacing.lg }}
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>Galerie</h1>
         <FilterBar
           selectedCategory={selectedCategory}
@@ -81,7 +87,7 @@ export default function Projects({ projects }) {
             ))}
           </AnimatePresence>
         </motion.ul>
-      </main>
+      </motion.main>
     </>
   );
 }

--- a/pages/services/index.js
+++ b/pages/services/index.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import { motion } from 'framer-motion';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -24,10 +25,15 @@ export default function Services() {
         <meta name="twitter:image" content={image} />
         <link rel="canonical" href={url} />
       </Head>
-      <main>
+      <motion.main
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
         <h1>Services</h1>
         <p>Description des services proposés.</p>
-      </main>
+      </motion.main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add Preloader component with simple spinner
- show Preloader before initial render in `_app`
- animate sections on scroll using framer-motion across main pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68972f2b28d8832484edc2aee428ffc9