### PR TITLE
Include privacy policy page in sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,7 @@
 export default {
   siteUrl: 'https://alex-chesnay.com',
   generateRobotsTxt: true,
+  additionalPaths: async (config) => [
+    await config.transform(config, '/politique-de-confidentialite'),
+  ],
 };

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://alex-chesnay.com
+
+# Sitemaps
+Sitemap: https://alex-chesnay.com/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://alex-chesnay.com</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/a-propos</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/contact</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/credits</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/mentions-legales</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/politique-de-confidentialite</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/projects</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://alex-chesnay.com/services</loc><lastmod>2025-08-09T11:31:08.115Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://alex-chesnay.com/sitemap-0.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary
- add privacy policy page to `next-sitemap` configuration
- regenerate `sitemap.xml`, `sitemap-0.xml` and `robots.txt`

## Testing
- `npm run build` *(fails: Class extends value #<Object> is not a constructor or null)*
- `npx next-sitemap`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973114d77c832485a5a650da4c4b9c