### PR TITLE
Add no-cache header for index and tidy headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -5,6 +5,7 @@
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com;
-
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
+/index.html
+  Cache-Control: no-cache


### PR DESCRIPTION
## Summary
- remove extra blank line between global and assets header blocks
- add `Cache-Control: no-cache` for `/index.html`

## Testing
- `npm test`
- `cat -A _headers`


------
https://chatgpt.com/codex/tasks/task_e_689740b341908324affe52ba6fe5afc0