### PR TITLE
Optimize image loading priorities

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@
       <div class="scroller" id="hero-scroller">
         <div class="scroller__content">
           <!-- move current top-gallery <img> elements here -->
-          <img class="top-img marquee-img" src="assets/images/ProjetGateauxRendu1.jpg" srcset="assets/images/ProjetGateauxRendu1.jpg" sizes="100vw" alt="Projet 1" decoding="async" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_3.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_3.jpg" sizes="100vw" alt="Projet 2" decoding="async" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="100vw" alt="Projet 3" decoding="async" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_2.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_2.jpg" sizes="100vw" alt="Projet 4" decoding="async" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="100vw" alt="Projet 5" decoding="async" />
+          <img class="top-img marquee-img" src="assets/images/ProjetGateauxRendu1.jpg" srcset="assets/images/ProjetGateauxRendu1.jpg" sizes="100vw" alt="Projet 1" decoding="async" fetchpriority="high" />
+          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_3.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_3.jpg" sizes="100vw" alt="Projet 2" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="100vw" alt="Projet 3" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_2.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_2.jpg" sizes="100vw" alt="Projet 4" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="100vw" alt="Projet 5" decoding="async" loading="lazy" />
         </div>
       </div>
     </section>

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -69,7 +69,7 @@ export default function Project({ project }) {
                   srcSet={`${img} 480w, ${img} 800w`}
                   sizes="(max-width: 600px) 100vw, 50vw"
                   alt={`${project.title} illustration ${idx + 1}`}
-                  loading="lazy"
+                  {...(idx === 0 ? { fetchPriority: 'high' } : { loading: 'lazy' })}
                   decoding="async"
                 />
               </Zoom>


### PR DESCRIPTION
## Summary
- prioritize first top gallery image using `fetchpriority="high"`
- lazily load remaining top images and project gallery images

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897478ae8e4832496ce9fc42239b678