### PR TITLE
Add site metadata for theme color and icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#1E90FF" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <meta name="description" content="Portfolio d'Alex Chesnay, spécialiste 3D, VFX et réalité virtuelle." />
   <meta property="og:title" content="Alex Chesnay Portfolio" />
   <meta property="og:description" content="Portfolio d'Alex Chesnay, spécialiste 3D, VFX et réalité virtuelle." />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,6 +5,9 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          <meta name="theme-color" content="#1E90FF" />
+          <link rel="icon" href="/favicon.ico" />
+          <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
           <link
             rel="preload"
             href="/fonts/Raleway-400.woff2"

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,9 +6,9 @@ import { motion } from 'framer-motion';
 const siteUrl = 'https://alex-chesnay.com';
 
 export default function Home() {
-  const title = 'Accueil - Alex Chesnay';
-  const description = 'Bienvenue sur mon portfolio.';
-  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const title = 'Alex Chesnay Portfolio';
+  const description = "Portfolio d'Alex Chesnay, spécialiste 3D, VFX et réalité virtuelle.";
+  const image = `${siteUrl}/assets/images/ProjetGateauxRendu1.jpg`;
   const url = `${siteUrl}/`;
 
   return (


### PR DESCRIPTION
## Summary
- add theme color and favicon links to static index
- inject theme color and icons in Next.js Document
- use final site title, description, and image for home page share tags

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68974b4493ac8324913894ca5c7c1979