### PR TITLE
fix: adjust asset paths and redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>404 - Page non trouvée</title>
+  <link rel="stylesheet" href="/css/style.min.css" />
 </head>
 <body>
   <h1>Page non trouvée</h1>

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,2 @@
-/* /index.html 200
 /instagram https://www.instagram.com/alexchesnay 301
 /linkedin https://www.linkedin.com/in/alexchesnay 301

--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
       <div class="scroller" id="hero-scroller">
         <div class="scroller__content">
           <!-- move current top-gallery <img> elements here -->
-          <img class="top-img marquee-img" src="assets/images/ProjetGateauxRendu1.jpg" srcset="assets/images/ProjetGateauxRendu1.jpg" sizes="100vw" alt="Rendu 3D de gâteaux colorés" decoding="async" fetchpriority="high" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_3.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_3.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac, vue arrière" decoding="async" loading="lazy" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac de face" decoding="async" loading="lazy" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_Cognac_2.jpg" srcset="assets/images/MENNECHET_Alex_Cognac_2.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac de côté" decoding="async" loading="lazy" />
-          <img class="top-img marquee-img" src="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="100vw" alt="Rendu 3D d’un flacon de parfum élégant" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="/assets/images/ProjetGateauxRendu1.jpg" srcset="/assets/images/ProjetGateauxRendu1.jpg" sizes="100vw" alt="Rendu 3D de gâteaux colorés" decoding="async" fetchpriority="high" />
+          <img class="top-img marquee-img" src="/assets/images/MENNECHET_Alex_Cognac_3.jpg" srcset="/assets/images/MENNECHET_Alex_Cognac_3.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac, vue arrière" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="/assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="/assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac de face" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="/assets/images/MENNECHET_Alex_Cognac_2.jpg" srcset="/assets/images/MENNECHET_Alex_Cognac_2.jpg" sizes="100vw" alt="Rendu 3D d’une bouteille de cognac de côté" decoding="async" loading="lazy" />
+          <img class="top-img marquee-img" src="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="100vw" alt="Rendu 3D d’un flacon de parfum élégant" decoding="async" loading="lazy" />
         </div>
       </div>
     </section>

--- a/work/project1.html
+++ b/work/project1.html
@@ -25,7 +25,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project1.png" srcset="../assets/images/project1.png" sizes="100vw" alt="Rendu principal du projet 1" class="hero-media" decoding="async" />
+    <img src="/assets/images/project1.png" srcset="/assets/images/project1.png" sizes="100vw" alt="Rendu principal du projet 1" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -49,7 +49,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project1.png" srcset="../assets/images/project1.png" sizes="100vw" alt="Vue de détail du projet 1" loading="lazy" decoding="async" />
+      <img src="/assets/images/project1.png" srcset="/assets/images/project1.png" sizes="100vw" alt="Vue de détail du projet 1" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/project2.html
+++ b/work/project2.html
@@ -25,7 +25,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project2.png" srcset="../assets/images/project2.png" sizes="100vw" alt="Rendu principal du projet 2" class="hero-media" decoding="async" />
+    <img src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="100vw" alt="Rendu principal du projet 2" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -49,7 +49,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project2.png" srcset="../assets/images/project2.png" sizes="100vw" alt="Vue de détail du projet 2" loading="lazy" decoding="async" />
+      <img src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="100vw" alt="Vue de détail du projet 2" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/project3.html
+++ b/work/project3.html
@@ -25,7 +25,7 @@
 </head>
 <body>
   <header class="project-hero">
-    <img src="../assets/images/project3.png" srcset="../assets/images/project3.png" sizes="100vw" alt="Rendu principal du projet 3" class="hero-media" decoding="async" />
+    <img src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="100vw" alt="Rendu principal du projet 3" class="hero-media" decoding="async" />
   </header>
   <main class="project-content">
     <section class="pitch">
@@ -49,7 +49,7 @@
     </section>
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/project3.png" srcset="../assets/images/project3.png" sizes="100vw" alt="Vue de détail du projet 3" loading="lazy" decoding="async" />
+      <img src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="100vw" alt="Vue de détail du projet 3" loading="lazy" decoding="async" />
     </section>
     <section class="cta">
       <h2>Intéressé ?</h2>

--- a/work/template.html
+++ b/work/template.html
@@ -10,7 +10,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://alexchesnay.com/" />
   <title>Project Template</title>
-  <link rel="stylesheet" href="../css/style.min.css">
+  <link rel="stylesheet" href="/css/style.min.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -26,7 +26,7 @@
 <body>
   <header class="project-hero">
     <!-- Hero image or video -->
-    <img src="../assets/images/placeholder2.png" srcset="../assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" />
+    <img src="/assets/images/placeholder2.png" srcset="/assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" />
   </header>
 
   <main class="project-content">
@@ -55,7 +55,7 @@
 
     <section class="gallery">
       <h2>Galerie</h2>
-      <img src="../assets/images/placeholder3.png" srcset="../assets/images/placeholder3.png" sizes="100vw" alt="Exemple d’image de galerie pour le modèle" loading="lazy" decoding="async" />
+      <img src="/assets/images/placeholder3.png" srcset="/assets/images/placeholder3.png" sizes="100vw" alt="Exemple d’image de galerie pour le modèle" loading="lazy" decoding="async" />
     </section>
 
     <section class="cta">


### PR DESCRIPTION
## Summary
- use root-relative paths for CSS and image assets across static HTML
- drop SPA redirect to allow direct access to project pages

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897a97b03a883249a8f87832519243a