### PR TITLE
feat: share site header and footer across pages

### DIFF
--- a/components/Layout/Footer.js
+++ b/components/Layout/Footer.js
@@ -1,0 +1,28 @@
+import theme from '../../styles/theme';
+import styles from './Footer.module.css';
+
+export default function Footer() {
+  return (
+    <footer
+      className={styles.footer}
+      style={{
+        background: theme.colors.background,
+        borderTop: `1px solid ${theme.colors.text}`,
+        color: theme.colors.text,
+        padding: theme.spacing.md
+      }}
+    >
+      <div className={styles.content}>
+        <a className={styles.phone} href="tel:0768563197">0768563197</a>
+        <div className={styles.bottom}>
+          <a className={styles.email} href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
+          <ul className={styles.social}>
+            <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener"><i className="fa-brands fa-instagram"></i></a></li>
+            <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn" target="_blank" rel="noopener"><i className="fa-brands fa-linkedin-in"></i></a></li>
+            <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation" target="_blank" rel="noopener"><i className="fa-brands fa-artstation"></i></a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/Layout/Footer.module.css
+++ b/components/Layout/Footer.module.css
@@ -1,0 +1,26 @@
+.footer {
+  display: flex;
+  justify-content: center;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.social {
+  display: flex;
+  list-style: none;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}

--- a/components/footer.html
+++ b/components/footer.html
@@ -1,0 +1,13 @@
+<footer class="site-footer">
+  <div class="footer-content">
+    <a class="footer-phone" href="tel:0768563197">0768563197</a>
+    <div class="footer-bottom">
+      <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
+      <ul class="social-icons">
+        <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
+        <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
+        <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
+      </ul>
+    </div>
+  </div>
+</footer>

--- a/components/header.html
+++ b/components/header.html
@@ -1,0 +1,11 @@
+<a class="skip-link" href="#main">Aller au contenu principal</a>
+<header class="site-header">
+  <nav class="site-pages">
+    <ul>
+      <li><a href="/work/project1.html">Project 1</a></li>
+      <li><a href="/work/project2.html">Project 2</a></li>
+      <li><a href="/work/project3.html">Project 3</a></li>
+    </ul>
+  </nav>
+  <a href="/contact.html" class="contact-button">Contact</a>
+</header>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#main">Aller au contenu principal</a>
+  <div id="header-placeholder"></div>
   <main id="main">
     <!-- Galerie supérieure (TOP) -->
     <section class="top-gallery hero-marquee">
@@ -71,15 +71,7 @@
           <li><a href="#">Virtual Reality</a></li>
         </ul>
       </nav>
-        <nav class="site-pages">
-          <ul>
-            <li><a href="/work/project1.html">Project 1</a></li>
-            <li><a href="/work/project2.html">Project 2</a></li>
-            <li><a href="/work/project3.html">Project 3</a></li>
-          </ul>
-        </nav>
-        <a href="/contact.html" class="contact-button">Contact</a>
-      </section>
+    </section>
 
     <!-- Galerie inférieure (BOTTOM) -->
     <section class="project-gallery">
@@ -97,22 +89,7 @@
       </div>
     </section>
   </main>
-
-    <!-- Footer with updated Font Awesome icons -->
-    <footer class="site-footer">
-      <div class="footer-content">
-        <a class="footer-phone" href="tel:0768563197">0768563197</a>
-        <div class="footer-bottom">
-          <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-          <ul class="social-icons">
-            <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
-            <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
-            <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
-          </ul>
-        </div>
-      </div>
-    </footer>
-
-    <script src="/js/script.min.js" defer></script>
-  </body>
-  </html>
+  <div id="footer-placeholder"></div>
+  <script src="/js/script.min.js" defer></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -14,9 +14,19 @@ function sanitizeInput(input) {
 
 window.sanitizeInput = sanitizeInput;
 
-  document.addEventListener('DOMContentLoaded', () => {
-    document.body.classList.add('loaded');
+document.addEventListener('DOMContentLoaded', () => {
+  ['header', 'footer'].forEach(name => {
+    const el = document.getElementById(`${name}-placeholder`);
+    if (el) {
+      fetch(`/components/${name}.html`)
+        .then(res => res.text())
+        .then(html => {
+          el.innerHTML = html;
+        });
+    }
   });
+  document.body.classList.add('loaded');
+});
 
 window.addEventListener('beforeunload', () => {
   document.body.classList.remove('loaded');

--- a/js/script.min.js
+++ b/js/script.min.js
@@ -1,1 +1,111 @@
-function sanitizeInput(e){const t=document.createElement('div');return t.textContent=e,t.innerHTML}window.sanitizeInput=sanitizeInput;document.addEventListener('DOMContentLoaded',()=>{document.body.classList.add('loaded');});window.addEventListener('beforeunload',()=>{document.body.classList.remove('loaded');});(()=>{const SPEED=40;const scroller=document.getElementById('hero-scroller');if(!scroller)return;const content=scroller.querySelector('.scroller__content');if(!content)return;const alreadyCloned=scroller.querySelectorAll('.scroller__content').length>1;if(!alreadyCloned){const clone=content.cloneNode(!0);clone.setAttribute('aria-hidden','true');scroller.appendChild(clone);}function setDuration(){const width=content.scrollWidth+parseFloat(getComputedStyle(scroller).gap||0),duration=width/SPEED;scroller.style.setProperty('--duration',`${duration}s`);}setDuration();let to;window.addEventListener('resize',()=>{clearTimeout(to);to=setTimeout(setDuration,150);});})();document.addEventListener("DOMContentLoaded",()=>{const e=document.querySelectorAll(".fade-in");if(window.matchMedia("(prefers-reduced-motion: reduce)").matches){e.forEach(o=>o.classList.add("in-view"));return}const o=new IntersectionObserver(t=>{t.forEach(r=>{r.isIntersecting&&(r.target.classList.add("in-view"),o.unobserve(r.target))})});e.forEach(t=>o.observe(t))});document.addEventListener("DOMContentLoaded",()=>{const e=document.querySelectorAll(".secondary-nav a"),t=document.querySelectorAll(".project-card");e.forEach(a=>{a.addEventListener("click",r=>{r.preventDefault();const c=a.textContent.trim();e.forEach(n=>{n.classList.remove("active"),n.removeAttribute("aria-current")}),a.classList.add("active"),a.setAttribute("aria-current","page"),t.forEach(n=>{const o=n.getAttribute("data-category");n.style.display="Featured"===c||o===c?"":"none"})})})});
+/*
+ * Fichier JavaScript principal pour le portfolio.
+ * Ce script gère simplement un menu responsive. D'autres interactions
+ * pourront être ajoutées ultérieurement.
+*/
+
+// Sanitize dynamic user-provided content to mitigate XSS attacks
+// Usage: const safe = window.sanitizeInput(userInput);
+function sanitizeInput(input) {
+  const div = document.createElement('div');
+  div.textContent = input;
+  return div.innerHTML;
+}
+
+window.sanitizeInput = sanitizeInput;
+
+document.addEventListener('DOMContentLoaded', () => {
+  ['header', 'footer'].forEach(name => {
+    const el = document.getElementById(`${name}-placeholder`);
+    if (el) {
+      fetch(`/components/${name}.html`)
+        .then(res => res.text())
+        .then(html => {
+          el.innerHTML = html;
+        });
+    }
+  });
+  document.body.classList.add('loaded');
+});
+
+window.addEventListener('beforeunload', () => {
+  document.body.classList.remove('loaded');
+});
+
+(() => {
+  const SPEED = 40; // pixels per second
+
+  const scroller = document.getElementById('hero-scroller');
+  if (!scroller) return;
+
+  const content = scroller.querySelector('.scroller__content');
+  if (!content) return;
+
+  const alreadyCloned = scroller.querySelectorAll('.scroller__content').length > 1;
+  if (!alreadyCloned) {
+    const clone = content.cloneNode(true);
+    clone.setAttribute('aria-hidden', 'true');
+    scroller.appendChild(clone);
+  }
+
+  function setDuration() {
+    const width = content.scrollWidth + parseFloat(getComputedStyle(scroller).gap || 0);
+    const duration = width / SPEED;
+    scroller.style.setProperty('--duration', `${duration}s`);
+  }
+
+  setDuration();
+  let to;
+  window.addEventListener('resize', () => {
+    clearTimeout(to);
+    to = setTimeout(setDuration, 150);
+  });
+})();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = document.querySelectorAll('.fade-in');
+
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    elements.forEach(el => el.classList.add('in-view'));
+    return;
+  }
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in-view');
+        observer.unobserve(entry.target);
+      }
+    });
+  });
+
+  elements.forEach(el => observer.observe(el));
+});
+
+// Filtering logic for static index.html gallery
+document.addEventListener('DOMContentLoaded', () => {
+  const navLinks = document.querySelectorAll('.secondary-nav a');
+  const cards = document.querySelectorAll('.project-card');
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const category = link.textContent.trim();
+
+      navLinks.forEach(l => {
+        l.classList.remove('active');
+        l.removeAttribute('aria-current');
+      });
+      link.classList.add('active');
+      link.setAttribute('aria-current', 'page');
+
+      cards.forEach(card => {
+        const cardCategory = card.getAttribute('data-category');
+        card.style.display =
+          category === 'Featured' || cardCategory === category
+            ? ''
+            : 'none';
+      });
+    });
+  });
+});

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Header from '../components/Layout/Header';
+import Footer from '../components/Layout/Footer';
 import CookieBanner from '../components/CookieBanner';
 import Preloader from '../components/Preloader';
 import theme from '../styles/theme';
@@ -50,6 +51,7 @@ export default function MyApp({ Component, pageProps }) {
           <Component {...pageProps} />
         </motion.div>
       </AnimatePresence>
+      <Footer />
     </div>
   );
 }

--- a/work/project1.html
+++ b/work/project1.html
@@ -28,14 +28,7 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#main">Aller au contenu principal</a>
-  <nav class="site-pages">
-    <ul>
-      <li><a href="/work/project1.html">Project 1</a></li>
-      <li><a href="/work/project2.html">Project 2</a></li>
-      <li><a href="/work/project3.html">Project 3</a></li>
-    </ul>
-  </nav>
+  <div id="header-placeholder"></div>
   <header class="project-hero">
     <img src="/assets/images/project1.png" srcset="/assets/images/project1.png" sizes="100vw" alt="Rendu principal du projet 1" class="hero-media" decoding="async" />
   </header>
@@ -72,19 +65,7 @@
     <a class="prev" href="/work/project3.html">Projet précédent</a>
     <a class="next" href="/work/project2.html">Projet suivant</a>
   </nav>
-  <footer class="site-footer">
-    <div class="footer-content">
-      <a class="footer-phone" href="tel:0768563197">0768563197</a>
-      <div class="footer-bottom">
-        <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-        <ul class="social-icons">
-          <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
-          <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
-          <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
-        </ul>
-      </div>
-    </div>
-  </footer>
+  <div id="footer-placeholder"></div>
   <script src="/js/script.min.js" defer></script>
 </body>
 </html>

--- a/work/project2.html
+++ b/work/project2.html
@@ -28,14 +28,7 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#main">Aller au contenu principal</a>
-  <nav class="site-pages">
-    <ul>
-      <li><a href="/work/project1.html">Project 1</a></li>
-      <li><a href="/work/project2.html">Project 2</a></li>
-      <li><a href="/work/project3.html">Project 3</a></li>
-    </ul>
-  </nav>
+  <div id="header-placeholder"></div>
   <header class="project-hero">
     <img src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="100vw" alt="Rendu principal du projet 2" class="hero-media" decoding="async" />
   </header>
@@ -72,19 +65,7 @@
     <a class="prev" href="/work/project1.html">Projet précédent</a>
     <a class="next" href="/work/project3.html">Projet suivant</a>
   </nav>
-  <footer class="site-footer">
-    <div class="footer-content">
-      <a class="footer-phone" href="tel:0768563197">0768563197</a>
-      <div class="footer-bottom">
-        <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-        <ul class="social-icons">
-          <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
-          <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
-          <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
-        </ul>
-      </div>
-    </div>
-  </footer>
+  <div id="footer-placeholder"></div>
   <script src="/js/script.min.js" defer></script>
 </body>
 </html>

--- a/work/project3.html
+++ b/work/project3.html
@@ -28,14 +28,7 @@
   </script>
 </head>
 <body>
-  <a class="skip-link" href="#main">Aller au contenu principal</a>
-  <nav class="site-pages">
-    <ul>
-      <li><a href="/work/project1.html">Project 1</a></li>
-      <li><a href="/work/project2.html">Project 2</a></li>
-      <li><a href="/work/project3.html">Project 3</a></li>
-    </ul>
-  </nav>
+  <div id="header-placeholder"></div>
   <header class="project-hero">
     <img src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="100vw" alt="Rendu principal du projet 3" class="hero-media" decoding="async" />
   </header>
@@ -72,19 +65,7 @@
     <a class="prev" href="/work/project2.html">Projet précédent</a>
     <a class="next" href="/work/project1.html">Projet suivant</a>
   </nav>
-  <footer class="site-footer">
-    <div class="footer-content">
-      <a class="footer-phone" href="tel:0768563197">0768563197</a>
-      <div class="footer-bottom">
-        <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-        <ul class="social-icons">
-          <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
-          <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
-          <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
-        </ul>
-      </div>
-    </div>
-  </footer>
+  <div id="footer-placeholder"></div>
   <script src="/js/script.min.js" defer></script>
 </body>
 </html>

--- a/work/template.html
+++ b/work/template.html
@@ -28,12 +28,13 @@
   </script>
 </head>
 <body>
+  <div id="header-placeholder"></div>
   <header class="project-hero">
     <!-- Hero image or video -->
     <img src="/assets/images/placeholder2.png" srcset="/assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" />
   </header>
 
-  <main class="project-content">
+  <main id="main" class="project-content">
     <section class="pitch">
       <h1>Titre du projet</h1>
       <p>Pitch du projet.</p>
@@ -72,18 +73,7 @@
     <a class="prev" href="#">Projet précédent</a>
     <a class="next" href="#">Projet suivant</a>
   </nav>
-  <footer class="site-footer">
-    <div class="footer-content">
-      <a class="footer-phone" href="tel:0768563197">0768563197</a>
-      <div class="footer-bottom">
-        <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-        <ul class="social-icons">
-          <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram d’Alex Chesnay" title="Instagram d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-instagram"></i></a></li>
-          <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn d’Alex Chesnay" title="LinkedIn d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-linkedin-in"></i></a></li>
-          <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation d’Alex Chesnay" title="ArtStation d’Alex Chesnay" target="_blank" rel="noopener"><i class="fa-brands fa-artstation"></i></a></li>
-        </ul>
-      </div>
-    </div>
-  </footer>
+  <div id="footer-placeholder"></div>
+  <script src="/js/script.min.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable HTML partials for header and footer
- load shared header and footer on static pages via script
- include new Footer component in Next.js layout

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68987740a8548324894f7a7c6ef3ce4b