### PR TITLE
fix: correct internal links and redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,7 @@
 /instagram https://www.instagram.com/alexchesnay 301
 /linkedin https://www.linkedin.com/in/alexchesnay 301
+/services.html /services 301
+/a-propos.html /a-propos 301
+/work /projects 301
+/work/ /projects 301
 /* /index.html 200

--- a/components/header.html
+++ b/components/header.html
@@ -4,9 +4,9 @@
   <nav class="site-pages" id="primary-menu">
     <ul>
       <li><a href="/index.html">Accueil</a></li>
-      <li><a href="/work/">Projets</a></li>
-      <li><a href="/services.html">Services</a></li>
-      <li><a href="/a-propos.html">À propos</a></li>
+      <li><a href="/projects">Projets</a></li>
+      <li><a href="/services">Services</a></li>
+      <li><a href="/a-propos">À propos</a></li>
       <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
## Summary
- fix navigation links to point to existing routes
- add redirects for legacy `.html` paths and `/work`

## Testing
- `npx linkinator file://`pwd`/index.html` *(fails: 403 Forbidden)*
- `npm test`
- `npm run lint` *(aborted: interactive prompt)*
- `npm run build` *(fails: TypeError: Class extends value <Object> is not a constructor or null)*

------
https://chatgpt.com/codex/tasks/task_e_6898975f89308324b7a135dd134c7a09