### PR TITLE
feat: add client trust section with logos

### DIFF
--- a/assets/images/clients/client1.svg
+++ b/assets/images/clients/client1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#007A9A"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#fff">C1</text>
+</svg>

--- a/assets/images/clients/client2.svg
+++ b/assets/images/clients/client2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#555"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#fff">C2</text>
+</svg>

--- a/assets/images/clients/client3.svg
+++ b/assets/images/clients/client3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ccc"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#000">C3</text>
+</svg>

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -56,6 +56,46 @@ export default function APropos() {
             chaque projet.
           </p>
         </section>
+        <section>
+          <h2>Ils nous font confiance</h2>
+          <blockquote>
+            « Une collaboration exceptionnelle ! » – Studio XYZ
+          </blockquote>
+          <blockquote>
+            « Des résultats au-delà de nos attentes. » – Agence 123
+          </blockquote>
+          <div
+            style={{
+              display: 'flex',
+              gap: '20px',
+              marginTop: '20px',
+              flexWrap: 'wrap'
+            }}
+          >
+            <img
+              src="/assets/images/clients/client1.svg"
+              alt="Logo Client 1"
+              style={{ maxWidth: '120px' }}
+            />
+            <img
+              src="/assets/images/clients/client2.svg"
+              alt="Logo Client 2"
+              style={{ maxWidth: '120px' }}
+            />
+            <img
+              src="/assets/images/clients/client3.svg"
+              alt="Logo Client 3"
+              style={{ maxWidth: '120px' }}
+            />
+          </div>
+        </section>
+        <section>
+          <h2>Certifications et affiliations</h2>
+          <p>
+            Nous sommes <strong>Autodesk Certified</strong> et membres de la
+            <strong> Fédération des créateurs numériques</strong>.
+          </p>
+        </section>
       </motion.main>
     </>
   );


### PR DESCRIPTION
## Summary
- add "Ils nous font confiance" section with testimonials and client logos on A Propos page
- mention certifications and affiliations
- add placeholder logos for client partners

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898b70559d88324b2ce39b16467e636