### PR TITLE
Expose desktop navigation and update contact CTAs

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -11,55 +11,71 @@ export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <nav
-      className={`${styles.nav} ${menuOpen ? styles.open : ''}`}
+    <header
+      className={styles.header}
       style={{
         background: theme.colors.background,
         borderBottom: `1px solid ${theme.colors.text}`,
         color: theme.colors.text,
-        gap: theme.spacing.md,
         padding: theme.spacing.md
       }}
     >
-      <button
-        className={styles.menuButton}
-        aria-label="Menu"
-        aria-expanded={menuOpen}
-        onClick={() => setMenuOpen(!menuOpen)}
+      <nav
+        className={`${styles.nav} ${menuOpen ? styles.open : ''}`}
+        style={{ gap: theme.spacing.md }}
       >
-        ☰
-      </button>
-      <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
-      <details
-        className={styles.dropdown}
-        open={projectsOpen}
-        onToggle={(e) => setProjectsOpen(e.target.open)}
-      >
-        <summary
-          aria-haspopup="menu"
-          aria-expanded={projectsOpen}
-          className={asPath.startsWith('/projects') ? styles.active : ''}
+        <button
+          className={styles.menuButton}
+          aria-label="Menu"
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen(!menuOpen)}
         >
-          Projets
-        </summary>
-        <ul className={styles.dropdownMenu} role="menu">
-          {projects.map((project) => (
-            <li key={project.slug} role="none">
-              <Link
-                href={`/projects/${project.slug}`}
-                className={asPath === `/projects/${project.slug}` ? styles.active : ''}
-                role="menuitem"
-              >
-                {project.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </details>
-      <Link href="/services" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
-      <Link href="/a-propos" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
-      <Link href="/blog" className={asPath.startsWith('/blog') ? styles.active : ''}>Blog</Link>
-      <Link href="/contact" className={asPath === '/contact' ? styles.active : ''}>Contact</Link>
-    </nav>
+          ☰
+        </button>
+        <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
+        <details
+          className={styles.dropdown}
+          open={projectsOpen}
+          onToggle={(e) => setProjectsOpen(e.target.open)}
+        >
+          <summary
+            aria-haspopup="menu"
+            aria-expanded={projectsOpen}
+            className={asPath.startsWith('/projects') ? styles.active : ''}
+          >
+            Projets
+          </summary>
+          <ul className={styles.dropdownMenu} role="menu">
+            {projects.map((project) => (
+              <li key={project.slug} role="none">
+                <Link
+                  href={`/projects/${project.slug}`}
+                  className={asPath === `/projects/${project.slug}` ? styles.active : ''}
+                  role="menuitem"
+                >
+                  {project.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </details>
+        <Link href="/services" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
+        <Link href="/a-propos" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
+        <Link href="/blog" className={asPath.startsWith('/blog') ? styles.active : ''}>Blog</Link>
+        <Link
+          href="/contact"
+          className={`${asPath === '/contact' ? styles.active : ''} ${styles.contactLink}`}
+        >
+          Contact
+        </Link>
+      </nav>
+      <Link
+        href="/contact"
+        className={styles.contactButton}
+        style={{ background: theme.colors.cyan, color: theme.colors.white }}
+      >
+        Contact
+      </Link>
+    </header>
   );
 }

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -1,10 +1,18 @@
-.nav {
+.header {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
+}
+
+.nav {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .menuButton {
@@ -55,6 +63,20 @@
   font-weight: bold;
 }
 
+.contactButton {
+  margin-left: auto;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: 700;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.contactButton:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
 @media (max-width: 768px) {
   .menuButton {
     display: flex;
@@ -68,4 +90,14 @@
   .open summary {
     display: flex;
   }
+  .contactButton {
+    display: none;
+  }
 }
+
+@media (min-width: 769px) {
+  .contactLink {
+    display: none;
+  }
+}
+

--- a/components/header.html
+++ b/components/header.html
@@ -11,5 +11,5 @@
       <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
-  <a href="/contact" class="contact-button">Contactez-nous</a>
+  <a href="/contact" class="contact-button-small">Contact</a>
 </header>

--- a/css/style.css
+++ b/css/style.css
@@ -466,6 +466,17 @@ nav {
   transform: none;
 }
 
+.site-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.site-pages {
+  flex: 1;
+  display: block;
+}
+
 .site-pages ul {
   display: flex;
   flex-wrap: wrap;
@@ -491,6 +502,22 @@ nav {
   font-size: var(--fs-24);
 }
 
+.contact-button-small {
+  margin-left: auto;
+  padding: var(--space-8) var(--space-16);
+  background-color: var(--cyan);
+  color: var(--white);
+  text-decoration: none;
+  border-radius: var(--space-4);
+  font-weight: 700;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.contact-button-small:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
 @media (max-width: 768px) {
   .menu-toggle {
     display: block;
@@ -506,6 +533,9 @@ nav {
     gap: var(--space-16);
     align-items: center;
   }
+  .contact-button-small {
+    display: none;
+  }
 }
 
 .contact-button,
@@ -513,15 +543,16 @@ nav {
   display: inline-block;
   margin-top: var(--space-24);
   padding: var(--space-10) var(--space-24);
-  background-color: #d90429;
+  background-color: var(--cyan);
   color: var(--white);
   text-decoration: none;
   border-radius: var(--space-4);
   font-weight: 700;
-  transition: background-color 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .contact-button:hover,
 .btn-contact:hover {
-  background-color: #9d021e;
+  opacity: 0.9;
+  transform: translateY(-2px);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -80,17 +80,18 @@ button {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.75rem 1.5rem;
-  background-color: #d90429;
+  background-color: #007A9A;
   color: #ffffff;
   text-decoration: none;
   border-radius: 4px;
   font-weight: 700;
-  transition: background-color 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .contact-button:hover,
 .btn-contact:hover {
-  background-color: #9d021e;
+  opacity: 0.9;
+  transform: translateY(-2px);
 }
 
 .project-hero .hero-media {


### PR DESCRIPTION
## Summary
- make top navigation visible and centered on desktop
- color "Contact" and "Réalisations" buttons with primary blue and subtle hover
- add small header contact button for quick access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c60acfd0832487cea0a7772376bb