### PR TITLE
style: enhance desktop nav link buttons

### DIFF
--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -100,6 +100,21 @@
     justify-content: flex-start;
   }
 
+  .nav a,
+  .nav summary {
+    background-color: var(--cyan);
+    color: var(--white);
+    border-radius: 4px;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    transition: background-color 0.3s ease;
+  }
+
+  .nav a:hover,
+  .nav summary:hover {
+    filter: brightness(1.1);
+  }
+
   .contactLink {
     display: none;
   }

--- a/css/style.css
+++ b/css/style.css
@@ -481,15 +481,21 @@ header h1 {
   justify-content: flex-start;
 }
 
-.site-pages a {
-  color: #7c7c7c;
-  text-decoration: none;
-  font-size: 18px;
-}
+@media (min-width: 769px) {
+  .site-pages a {
+    background-color: var(--cyan);
+    color: var(--white);
+    text-decoration: none;
+    font-size: 18px;
+    border-radius: var(--space-4);
+    font-weight: 700;
+    padding: var(--space-10) var(--space-24);
+    transition: background-color 0.3s ease;
+  }
 
-.site-pages a:hover {
-  color: #00bfe8;
-  text-decoration: underline;
+  .site-pages a:hover {
+    filter: brightness(1.1);
+  }
 }
 
 .menu-toggle {


### PR DESCRIPTION
## Summary
- Style desktop `.site-pages` links as cyan buttons with hover transition.
- Extend header nav links to use cyan background, white text, and hover brightness on desktop.

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898f02525e48324881d905f9355985e