### PR TITLE
Use root URL for home link in header navigation

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -3,7 +3,7 @@
   <button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">Menu</button>
   <nav class="site-pages" id="primary-menu">
     <ul>
-      <li><a href="/index.html">Accueil</a></li>
+      <li><a href="/">Accueil</a></li>
       <li><a href="/projects">Projets</a></li>
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>


### PR DESCRIPTION
## Summary
- link "Accueil" to the site root instead of /index.html
- confirm other header links use extensionless URLs

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898f55388848324bf4429b31f2c1873