### PR TITLE
Use extensionless routes in navigation

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,3 +4,10 @@
 /a-propos.html /a-propos 301
 /work /projects 301
 /work/ /projects 301
+/mentions-legales.html /mentions-legales 301
+/politique-confidentialite.html /politique-de-confidentialite 301
+/animation-3d.html /animation-3d 301
+/animation-2d.html /animation-2d 301
+/vfx.html /vfx 301
+/virtual-reality.html /virtual-reality 301
+/work/:slug.html /projects/:slug 301

--- a/animation-2d.html
+++ b/animation-2d.html
@@ -22,7 +22,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -38,8 +37,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/animation-3d.html
+++ b/animation-3d.html
@@ -22,7 +22,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -38,8 +37,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/components/footer.html
+++ b/components/footer.html
@@ -4,8 +4,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/components/header.html
+++ b/components/header.html
@@ -8,7 +8,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -80,11 +79,11 @@
       <h1 class="logo">Alex Chesnay</h1>
       <nav class="secondary-nav open">
         <ul>
-          <li><a href="/index.html" class="active" aria-current="page">Featured</a></li>
-          <li><a href="/animation-3d.html">3D Animation</a></li>
-          <li><a href="/animation-2d.html">2D Animation</a></li>
-          <li><a href="/vfx.html">VFX</a></li>
-          <li><a href="/virtual-reality.html">Virtual Reality</a></li>
+          <li><a href="/" class="active" aria-current="page">Featured</a></li>
+          <li><a href="/animation-3d">3D Animation</a></li>
+          <li><a href="/animation-2d">2D Animation</a></li>
+          <li><a href="/vfx">VFX</a></li>
+          <li><a href="/virtual-reality">Virtual Reality</a></li>
         </ul>
       </nav>
       <a href="#projects" class="btn-contact">Voir nos réalisations</a>
@@ -112,8 +111,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/public/mentions-legales.html
+++ b/public/mentions-legales.html
@@ -19,7 +19,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -58,8 +57,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/public/politique-confidentialite.html
+++ b/public/politique-confidentialite.html
@@ -19,7 +19,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -54,8 +53,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/vfx.html
+++ b/vfx.html
@@ -22,7 +22,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -38,8 +37,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/virtual-reality.html
+++ b/virtual-reality.html
@@ -22,7 +22,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -38,8 +37,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/work/project1.html
+++ b/work/project1.html
@@ -40,7 +40,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -88,8 +87,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/work/project2.html
+++ b/work/project2.html
@@ -40,7 +40,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -88,8 +87,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/work/project3.html
+++ b/work/project3.html
@@ -40,7 +40,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -88,8 +87,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">

--- a/work/template.html
+++ b/work/template.html
@@ -40,7 +40,6 @@
       <li><a href="/services">Services</a></li>
       <li><a href="/a-propos">À propos</a></li>
       <li><a href="/blog">Blog</a></li>
-      <li><a href="/contact">Contact</a></li>
     </ul>
   </nav>
   <a href="/contact" class="contact-button-small">Contact</a>
@@ -96,8 +95,8 @@
     <div class="footer-bottom">
       <a class="footer-email" href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
       <ul class="footer-links">
-        <li><a href="/mentions-legales.html">Mentions légales</a></li>
-        <li><a href="/politique-confidentialite.html">Politique de confidentialité</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/politique-de-confidentialite">Politique de confidentialité</a></li>
       </ul>
       <div class="footer-socials" aria-label="Réseaux sociaux">
         <a href="https://instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
- remove contact menu item now that contact button covers it
- switch header and footer links to root-relative paths without `.html`
- redirect old `.html` URLs to their Next.js routes

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6899be07308483248a0053cc24a479b1