### PR TITLE
feat: load cdnjs font awesome brands consistently

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,7 +4,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com;
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 /index.html

--- a/animation-2d.html
+++ b/animation-2d.html
@@ -6,10 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Projets d'animation 2D du portfolio d'Alex Chesnay." />
   <title>Animation 2D – Alex Chesnay Portfolio</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/animation-3d.html
+++ b/animation-3d.html
@@ -6,10 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Projets d'animation 3D du portfolio d'Alex Chesnay." />
   <title>Animation 3D – Alex Chesnay Portfolio</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/index.html
+++ b/index.html
@@ -23,11 +23,17 @@
   />
     <!-- Main stylesheet -->
     <link rel="stylesheet" href="/css/style.min.css" />
-  <!-- Font Awesome for social icons -->
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+    <!-- Font Awesome for social icons -->
+    <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
+    <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,12 +9,18 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#1E90FF" />
           <link rel="icon" href="/favicon.ico" />
           <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-          <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-            crossOrigin="anonymous"
-            referrerPolicy="no-referrer"
-          />
+            <link
+              rel="stylesheet"
+              href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+              crossOrigin="anonymous"
+              referrerPolicy="no-referrer"
+            />
+            <link
+              rel="stylesheet"
+              href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+              crossOrigin="anonymous"
+              referrerPolicy="no-referrer"
+            />
           <link
             rel="preload"
             href="/fonts/Raleway-400.woff2"

--- a/public/mentions-legales.html
+++ b/public/mentions-legales.html
@@ -5,8 +5,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mentions légales - Alex Chesnay</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/public/politique-confidentialite.html
+++ b/public/politique-confidentialite.html
@@ -5,8 +5,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Politique de confidentialité - Alex Chesnay</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/vfx.html
+++ b/vfx.html
@@ -6,10 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Projets VFX du portfolio d'Alex Chesnay." />
   <title>VFX – Alex Chesnay Portfolio</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/virtual-reality.html
+++ b/virtual-reality.html
@@ -6,10 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Projets de réalité virtuelle du portfolio d'Alex Chesnay." />
   <title>Réalité Virtuelle – Alex Chesnay Portfolio</title>
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css" />
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous" referrerpolicy="no-referrer">
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>

--- a/work/project1.html
+++ b/work/project1.html
@@ -12,11 +12,15 @@
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://alexchesnay.com/work/project1.html" />
   <title>Project 1</title>
-  <link rel="stylesheet" href="/css/style.min.css">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/work/project2.html
+++ b/work/project2.html
@@ -12,11 +12,15 @@
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://alexchesnay.com/work/project2.html" />
   <title>Project 2</title>
-  <link rel="stylesheet" href="/css/style.min.css">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/work/project3.html
+++ b/work/project3.html
@@ -12,11 +12,15 @@
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://alexchesnay.com/work/project3.html" />
   <title>Project 3</title>
-  <link rel="stylesheet" href="/css/style.min.css">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/work/template.html
+++ b/work/template.html
@@ -12,11 +12,15 @@
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://alexchesnay.com/" />
   <title>Project Template</title>
-  <link rel="stylesheet" href="/css/style.min.css">
-  <link rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer">
+    <link rel="stylesheet" href="/css/style.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- expand CSP to allow cdnjs styles and fonts
- use Font Awesome 6.5.2 core and brands modules across static and Next.js pages

## Testing
- `npm test`
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6899c1d3785883248b65b0e4285eb5ea