### PR TITLE
Add basic blog pages with article placeholders

### DIFF
--- a/blog/deuxieme-article/index.html
+++ b/blog/deuxieme-article/index.html
@@ -4,13 +4,13 @@
   <script>document.documentElement.classList.add('js');</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:title" content="Blog - Alex Chesnay" />
-  <meta property="og:description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:type" content="website" />
+  <meta name="description" content="Placeholder pour le deuxième article du blog d'Alex Chesnay." />
+  <meta property="og:title" content="Deuxième article - Alex Chesnay" />
+  <meta property="og:description" content="Placeholder pour le deuxième article du blog d'Alex Chesnay." />
+  <meta property="og:type" content="article" />
   <meta property="og:image" content="https://alexchesnay.com/assets/images/ProjetGateauxRendu1.jpg" />
-  <link rel="canonical" href="https://alexchesnay.com/blog/" />
-  <title>Blog - Alex Chesnay</title>
+  <link rel="canonical" href="https://alexchesnay.com/blog/deuxieme-article/" />
+  <title>Deuxième article - Alex Chesnay</title>
   <link rel="stylesheet" href="/css/style.min.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
@@ -32,33 +32,11 @@
   </header>
 
   <main id="main">
-    <h1>Blog</h1>
-    <p>Découvrez les dernières actualités et projets.</p>
-
-    <section class="articles">
-      <article class="article-card">
-        <h2>Premier article</h2>
-        <p class="article-date">1 janvier 2024</p>
-        <p>Un aperçu rapide de notre premier article.</p>
-        <a href="/blog/premier-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Deuxième article</h2>
-        <p class="article-date">15 février 2024</p>
-        <p>Quelques mots sur un second sujet passionnant.</p>
-        <a href="/blog/deuxieme-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Troisième article</h2>
-        <p class="article-date">30 mars 2024</p>
-        <p>Un extrait du troisième article pour susciter l'intérêt.</p>
-        <a href="/blog/troisieme-article/" class="btn-read">Lire</a>
-      </article>
-    </section>
-
-    <button class="load-more" disabled>Charger plus</button>
+    <article>
+      <h1>Deuxième article</h1>
+      <p class="article-date">15 février 2024</p>
+      <p>Contenu de démonstration pour le deuxième article.</p>
+    </article>
 
     <section class="cta-contact">
       <a href="/contact/" class="btn-contact">Nous contacter</a>

--- a/blog/premier-article/index.html
+++ b/blog/premier-article/index.html
@@ -4,13 +4,13 @@
   <script>document.documentElement.classList.add('js');</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:title" content="Blog - Alex Chesnay" />
-  <meta property="og:description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:type" content="website" />
+  <meta name="description" content="Placeholder pour le premier article du blog d'Alex Chesnay." />
+  <meta property="og:title" content="Premier article - Alex Chesnay" />
+  <meta property="og:description" content="Placeholder pour le premier article du blog d'Alex Chesnay." />
+  <meta property="og:type" content="article" />
   <meta property="og:image" content="https://alexchesnay.com/assets/images/ProjetGateauxRendu1.jpg" />
-  <link rel="canonical" href="https://alexchesnay.com/blog/" />
-  <title>Blog - Alex Chesnay</title>
+  <link rel="canonical" href="https://alexchesnay.com/blog/premier-article/" />
+  <title>Premier article - Alex Chesnay</title>
   <link rel="stylesheet" href="/css/style.min.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
@@ -32,33 +32,11 @@
   </header>
 
   <main id="main">
-    <h1>Blog</h1>
-    <p>Découvrez les dernières actualités et projets.</p>
-
-    <section class="articles">
-      <article class="article-card">
-        <h2>Premier article</h2>
-        <p class="article-date">1 janvier 2024</p>
-        <p>Un aperçu rapide de notre premier article.</p>
-        <a href="/blog/premier-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Deuxième article</h2>
-        <p class="article-date">15 février 2024</p>
-        <p>Quelques mots sur un second sujet passionnant.</p>
-        <a href="/blog/deuxieme-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Troisième article</h2>
-        <p class="article-date">30 mars 2024</p>
-        <p>Un extrait du troisième article pour susciter l'intérêt.</p>
-        <a href="/blog/troisieme-article/" class="btn-read">Lire</a>
-      </article>
-    </section>
-
-    <button class="load-more" disabled>Charger plus</button>
+    <article>
+      <h1>Premier article</h1>
+      <p class="article-date">1 janvier 2024</p>
+      <p>Contenu de démonstration pour le premier article.</p>
+    </article>
 
     <section class="cta-contact">
       <a href="/contact/" class="btn-contact">Nous contacter</a>

--- a/blog/troisieme-article/index.html
+++ b/blog/troisieme-article/index.html
@@ -4,13 +4,13 @@
   <script>document.documentElement.classList.add('js');</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:title" content="Blog - Alex Chesnay" />
-  <meta property="og:description" content="Articles et actualités d'Alex Chesnay." />
-  <meta property="og:type" content="website" />
+  <meta name="description" content="Placeholder pour le troisième article du blog d'Alex Chesnay." />
+  <meta property="og:title" content="Troisième article - Alex Chesnay" />
+  <meta property="og:description" content="Placeholder pour le troisième article du blog d'Alex Chesnay." />
+  <meta property="og:type" content="article" />
   <meta property="og:image" content="https://alexchesnay.com/assets/images/ProjetGateauxRendu1.jpg" />
-  <link rel="canonical" href="https://alexchesnay.com/blog/" />
-  <title>Blog - Alex Chesnay</title>
+  <link rel="canonical" href="https://alexchesnay.com/blog/troisieme-article/" />
+  <title>Troisième article - Alex Chesnay</title>
   <link rel="stylesheet" href="/css/style.min.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
@@ -32,33 +32,11 @@
   </header>
 
   <main id="main">
-    <h1>Blog</h1>
-    <p>Découvrez les dernières actualités et projets.</p>
-
-    <section class="articles">
-      <article class="article-card">
-        <h2>Premier article</h2>
-        <p class="article-date">1 janvier 2024</p>
-        <p>Un aperçu rapide de notre premier article.</p>
-        <a href="/blog/premier-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Deuxième article</h2>
-        <p class="article-date">15 février 2024</p>
-        <p>Quelques mots sur un second sujet passionnant.</p>
-        <a href="/blog/deuxieme-article/" class="btn-read">Lire</a>
-      </article>
-
-      <article class="article-card">
-        <h2>Troisième article</h2>
-        <p class="article-date">30 mars 2024</p>
-        <p>Un extrait du troisième article pour susciter l'intérêt.</p>
-        <a href="/blog/troisieme-article/" class="btn-read">Lire</a>
-      </article>
-    </section>
-
-    <button class="load-more" disabled>Charger plus</button>
+    <article>
+      <h1>Troisième article</h1>
+      <p class="article-date">30 mars 2024</p>
+      <p>Contenu de démonstration pour le troisième article.</p>
+    </article>
 
     <section class="cta-contact">
       <a href="/contact/" class="btn-contact">Nous contacter</a>


### PR DESCRIPTION
## Summary
- expand blog index with intro, article cards, pagination and contact CTA
- add three placeholder article pages each with meta tags and contact CTA
- include meta description, OG tags, canonical links and aria-current for blog navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d82d95c883249b8d947c17343232