### PR TITLE
feat: add shared layout container

### DIFF
--- a/components/Layout/Footer.js
+++ b/components/Layout/Footer.js
@@ -9,26 +9,28 @@ export default function Footer() {
         background: theme.colors.background,
         borderTop: `1px solid ${theme.colors.text}`,
         color: theme.colors.text,
-        padding: theme.spacing.md
+        padding: 'var(--space-md) 0'
       }}
     >
-      <div className={styles.content}>
-        <a className={styles.phone} href="tel:0768563197">0768563197</a>
-        <div className={styles.bottom}>
-          <a className={styles.email} href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
-          <ul className={styles.links}>
-            <li>
-              <a href="/mentions-legales.html">Mentions légales</a>
-            </li>
-            <li>
-              <a href="/politique-confidentialite.html">Politique de confidentialité</a>
-            </li>
-          </ul>
-          <ul className={styles.social}>
-            <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener"><i className="fa-brands fa-instagram"></i></a></li>
-            <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn" target="_blank" rel="noopener"><i className="fa-brands fa-linkedin-in"></i></a></li>
-            <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation" target="_blank" rel="noopener"><i className="fa-brands fa-artstation"></i></a></li>
-          </ul>
+      <div className="container">
+        <div className={styles.content}>
+          <a className={styles.phone} href="tel:0768563197">0768563197</a>
+          <div className={styles.bottom}>
+            <a className={styles.email} href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
+            <ul className={styles.links}>
+              <li>
+                <a href="/mentions-legales.html">Mentions légales</a>
+              </li>
+              <li>
+                <a href="/politique-confidentialite.html">Politique de confidentialité</a>
+              </li>
+            </ul>
+            <ul className={styles.social}>
+              <li><a href="https://www.instagram.com/alexchesnay" aria-label="Instagram" target="_blank" rel="noopener"><i className="fa-brands fa-instagram"></i></a></li>
+              <li><a href="https://www.linkedin.com/in/alexchesnay" aria-label="LinkedIn" target="_blank" rel="noopener"><i className="fa-brands fa-linkedin-in"></i></a></li>
+              <li><a href="https://www.artstation.com/alexchesnay" aria-label="ArtStation" target="_blank" rel="noopener"><i className="fa-brands fa-artstation"></i></a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </footer>

--- a/components/Layout/Footer.module.css
+++ b/components/Layout/Footer.module.css
@@ -7,20 +7,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-xs);
 }
 
 .bottom {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-xs);
 }
 
 .links {
   display: flex;
   list-style: none;
-  gap: 0.5rem;
+  gap: var(--space-xs);
   padding: 0;
   margin: 0;
 }
@@ -28,7 +28,7 @@
 .social {
   display: flex;
   list-style: none;
-  gap: 0.5rem;
+  gap: var(--space-xs);
   padding: 0;
   margin: 0;
 }

--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -17,67 +17,69 @@ export default function Header() {
         background: theme.colors.background,
         borderBottom: `1px solid ${theme.colors.text}`,
         color: theme.colors.text,
-        padding: theme.spacing.md
+        padding: 'var(--space-md) 0'
       }}
     >
-      <nav
-        className={`${styles.nav} ${menuOpen ? styles.open : ''}`}
-        style={{ gap: theme.spacing.md }}
-      >
-        <button
-          className={styles.menuButton}
-          aria-label="Menu"
-          aria-expanded={menuOpen}
-          onClick={() => setMenuOpen(!menuOpen)}
+      <div className={`container ${styles.inner}`}>
+        <nav
+          className={`${styles.nav} ${menuOpen ? styles.open : ''}`}
+          style={{ gap: 'var(--space-md)' }}
         >
-          ☰
-        </button>
-        <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
-        <details
-          className={styles.dropdown}
-          open={projectsOpen}
-          onToggle={(e) => setProjectsOpen(e.target.open)}
-        >
-          <summary
-            aria-haspopup="menu"
-            aria-expanded={projectsOpen}
-            className={asPath.startsWith('/projets') ? styles.active : ''}
+          <button
+            className={styles.menuButton}
+            aria-label="Menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen(!menuOpen)}
           >
-            Projets
-          </summary>
-          <ul className={styles.dropdownMenu} role="menu">
-            {projects.map((project) => (
-              <li key={project.slug} role="none">
-                <Link
-                  href={`/projets/${project.slug}`}
-                  className={asPath === `/projets/${project.slug}` ? styles.active : ''}
-                  role="menuitem"
-                >
-                  {project.title}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </details>
-        <Link href="/services/" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
-        <Link href="/a-propos/" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
-        <Link href="/blog/" className={asPath.startsWith('/blog') ? styles.active : ''}>Blog</Link>
+            ☰
+          </button>
+          <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
+          <details
+            className={styles.dropdown}
+            open={projectsOpen}
+            onToggle={(e) => setProjectsOpen(e.target.open)}
+          >
+            <summary
+              aria-haspopup="menu"
+              aria-expanded={projectsOpen}
+              className={asPath.startsWith('/projets') ? styles.active : ''}
+            >
+              Projets
+            </summary>
+            <ul className={styles.dropdownMenu} role="menu">
+              {projects.map((project) => (
+                <li key={project.slug} role="none">
+                  <Link
+                    href={`/projets/${project.slug}`}
+                    className={asPath === `/projets/${project.slug}` ? styles.active : ''}
+                    role="menuitem"
+                  >
+                    {project.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </details>
+          <Link href="/services/" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
+          <Link href="/a-propos/" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
+          <Link href="/blog/" className={asPath.startsWith('/blog') ? styles.active : ''}>Blog</Link>
+          <Link
+            href="/contact/"
+            aria-current={asPath === '/contact' ? 'page' : undefined}
+            className={`${asPath === '/contact' ? styles.active : ''} ${styles.contactLink}`}
+          >
+            Contact
+          </Link>
+        </nav>
         <Link
           href="/contact/"
           aria-current={asPath === '/contact' ? 'page' : undefined}
-          className={`${asPath === '/contact' ? styles.active : ''} ${styles.contactLink}`}
+          className={styles.contactButton}
+          style={{ background: theme.colors.cyan, color: theme.colors.white }}
         >
           Contact
         </Link>
-      </nav>
-      <Link
-        href="/contact/"
-        aria-current={asPath === '/contact' ? 'page' : undefined}
-        className={styles.contactButton}
-        style={{ background: theme.colors.cyan, color: theme.colors.white }}
-      >
-        Contact
-      </Link>
+      </div>
     </header>
   );
 }

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -3,6 +3,9 @@
   top: 0;
   left: 0;
   right: 0;
+}
+
+.inner {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -26,7 +29,7 @@
 .nav a,
 .nav summary {
   text-decoration: none;
-  padding: 0.75rem 1rem;
+  padding: var(--space-sm) var(--space-md);
   min-height: 44px;
   display: flex;
   align-items: center;
@@ -65,7 +68,7 @@
 
 .contactButton {
   margin-left: auto;
-  padding: 0.5rem 1rem;
+  padding: var(--space-xs) var(--space-md);
   text-decoration: none;
   border-radius: 4px;
   font-weight: 700;
@@ -106,7 +109,7 @@
     color: var(--white);
     border-radius: 4px;
     font-weight: 700;
-    padding: 0.5rem 1rem;
+    padding: var(--space-xs) var(--space-md);
     transition: background-color 0.3s ease;
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,6 +30,20 @@
   font-display: swap;
 }
 
+:root {
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --max-width: 1200px;
+}
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+  width: 100%;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -42,7 +56,7 @@ body {
 .responsive-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  gap: var(--space-md);
 }
 
 .video-wrapper {
@@ -60,7 +74,7 @@ body {
 }
 
 button {
-  padding: 0.75rem 1rem;
+  padding: var(--space-sm) var(--space-md);
   min-height: 44px;
 }
 
@@ -103,7 +117,7 @@ button {
 .project-nav {
   display: flex;
   justify-content: space-between;
-  padding: 1rem;
+  padding: var(--space-md);
 }
 
 .back-link {


### PR DESCRIPTION
## Summary
- centralize layout with container class and CSS variables
- align header links left and contact button right on large screens
- standardize spacing via globals

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1ecc9c08324a679475ba1023b78