### PR TITLE
Harmonise la palette des liens du header avec le bouton Contact

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -33,7 +33,7 @@ export default function Header() {
           >
             ☰
           </button>
-          <Link href="/" className={asPath === '/' ? styles.active : ''}>Accueil</Link>
+          <Link href="/" className={`${styles.navLink} ${asPath === '/' ? styles.active : ''}`}>Accueil</Link>
           <details
             className={styles.dropdown}
             open={projectsOpen}
@@ -42,7 +42,9 @@ export default function Header() {
             <summary
               aria-haspopup="menu"
               aria-expanded={projectsOpen}
-              className={asPath.startsWith('/projets') ? styles.active : ''}
+              className={`${styles.navLink} ${
+                asPath.startsWith('/projets') ? styles.active : ''
+              }`}
             >
               Projets
             </summary>
@@ -51,7 +53,9 @@ export default function Header() {
                 <li key={project.slug} role="none">
                   <Link
                     href={`/projets/${project.slug}`}
-                    className={asPath === `/projets/${project.slug}` ? styles.active : ''}
+                    className={`${styles.navLink} ${
+                      asPath === `/projets/${project.slug}` ? styles.active : ''
+                    }`}
                     role="menuitem"
                   >
                     {project.title}
@@ -60,13 +64,30 @@ export default function Header() {
               ))}
             </ul>
           </details>
-          <Link href="/services/" className={asPath.startsWith('/services') ? styles.active : ''}>Services</Link>
-          <Link href="/a-propos/" className={asPath === '/a-propos' ? styles.active : ''}>À propos</Link>
-          <Link href="/blog/" className={asPath.startsWith('/blog') ? styles.active : ''}>Blog</Link>
+          <Link
+            href="/services/"
+            className={`${styles.navLink} ${asPath.startsWith('/services') ? styles.active : ''}`}
+          >
+            Services
+          </Link>
+          <Link
+            href="/a-propos/"
+            className={`${styles.navLink} ${asPath === '/a-propos' ? styles.active : ''}`}
+          >
+            À propos
+          </Link>
+          <Link
+            href="/blog/"
+            className={`${styles.navLink} ${asPath.startsWith('/blog') ? styles.active : ''}`}
+          >
+            Blog
+          </Link>
           <Link
             href="/contact/"
             aria-current={asPath === '/contact' ? 'page' : undefined}
-            className={`${asPath === '/contact' ? styles.active : ''} ${styles.contactLink}`}
+            className={`${styles.navLink} ${
+              asPath === '/contact' ? styles.active : ''
+            } ${styles.contactLink}`}
           >
             Contact
           </Link>

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -29,7 +29,6 @@
 .nav a,
 .nav summary {
   text-decoration: none;
-  padding: var(--space-sm) var(--space-md);
   min-height: 44px;
   display: flex;
   align-items: center;
@@ -64,6 +63,26 @@
 
 .active {
   font-weight: bold;
+}
+
+.navLink {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  padding: var(--space-xs) var(--space-md);
+  text-decoration: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.navLink:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+.navLink:active {
+  opacity: 0.8;
+  transform: translateY(0);
 }
 
 .contactButton {
@@ -101,21 +120,6 @@
 @media (min-width: 769px) {
   .nav {
     justify-content: flex-start;
-  }
-
-  .nav a,
-  .nav summary {
-    background-color: var(--color-primary);
-    color: var(--color-white);
-    border-radius: var(--radius-sm);
-    font-weight: 700;
-    padding: var(--space-xs) var(--space-md);
-    transition: background-color 0.3s ease;
-  }
-
-  .nav a:hover,
-  .nav summary:hover {
-    filter: brightness(1.1);
   }
 
   .contactLink {


### PR DESCRIPTION
## Summary
- Aligne la palette de couleurs et les transitions des liens de navigation sur celles du bouton Contact
- Ajoute des états `:hover` et `:active` aux liens du header pour une interaction homogène

## Testing
- `npm test`
- `npm run lint` *(prompt de configuration ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6899f9413f088324b58a2739009050e8