### PR TITLE
Add BlogCard component with load-more button

### DIFF
--- a/components/BlogCard.js
+++ b/components/BlogCard.js
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import styles from './BlogCard.module.css';
+
+export default function BlogCard({ title, date, excerpt, slug, image = '/assets/images/placeholder2.png' }) {
+  return (
+    <article className={styles.card}>
+      <div className={styles.imageWrapper}>
+        <img src={image} alt={title} className={styles.image} />
+      </div>
+      <div className={styles.content}>
+        <h2 className={styles.title}>{title}</h2>
+        <time className={styles.date}>{date}</time>
+        <p className={styles.excerpt}>{excerpt}</p>
+        <Link href={`/blog/${slug}`} className={`contact-button ${styles.readButton}`}>
+          Lire
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/components/BlogCard.module.css
+++ b/components/BlogCard.module.css
@@ -1,0 +1,62 @@
+.card {
+  background: var(--color-white);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+.imageWrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+  display: block;
+}
+
+.card:hover .image,
+.card:focus-within .image {
+  transform: scale(1.05);
+}
+
+.content {
+  padding: var(--space-md);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  margin: 0 0 var(--space-sm);
+  font-size: 1.25rem;
+}
+
+.date {
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.excerpt {
+  margin: var(--space-sm) 0 var(--space-md);
+  flex: 1;
+}
+
+.readButton {
+  margin-top: auto;
+}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,9 +1,27 @@
 import Head from 'next/head';
-import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { useState } from 'react';
 import theme from '../../styles/theme';
+import BlogCard from '../../components/BlogCard';
 
 const siteUrl = 'https://alex-chesnay.com';
+
+const posts = [
+  {
+    slug: 'premier-article',
+    title: 'Premier article',
+    date: '1 janvier 2023',
+    excerpt: "Introduction au blog et premières actualités.",
+    image: '/assets/images/placeholder2.png'
+  },
+  {
+    slug: 'studio-animation-3d',
+    title: "Studio d'animation 3D : nouveautés",
+    date: '15 février 2023',
+    excerpt: "Les dernières nouveautés du studio d'animation 3D.",
+    image: '/assets/images/placeholder3.png'
+  }
+];
 
 export default function Blog() {
   const title = "Blog - Studio d'animation 3D Alex Chesnay";
@@ -11,6 +29,9 @@ export default function Blog() {
     "Actualités du studio d'animation 3D et articles récents.";
   const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
   const url = `${siteUrl}/blog`;
+  const [visibleCount, setVisibleCount] = useState(1);
+
+  const loadMore = () => setVisibleCount((c) => c + 1);
 
   return (
     <>
@@ -36,14 +57,18 @@ export default function Blog() {
         transition={{ duration: 0.5 }}
       >
         <h1>Blog du studio d'animation 3D</h1>
-        <ul>
-          <li>
-            <Link href="/blog/premier-article">Premier article</Link>
-          </li>
-          <li>
-            <Link href="/blog/studio-animation-3d">Studio d'animation 3D : nouveautés</Link>
-          </li>
-        </ul>
+        <div className="responsive-grid">
+          {posts.slice(0, visibleCount).map((post) => (
+            <BlogCard key={post.slug} {...post} />
+          ))}
+        </div>
+        {visibleCount < posts.length && (
+          <div style={{ textAlign: 'center', marginTop: theme.spacing.lg }}>
+            <button onClick={loadMore} className="contact-button">
+              Charger plus
+            </button>
+          </div>
+        )}
       </motion.main>
     </>
   );


### PR DESCRIPTION
## Summary
- add reusable BlogCard with image, meta and 'Lire' CTA
- display blog posts as BlogCard grid and include a `Charger plus` button

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a0c48fc24832493b23dc6f7dc6edb