### PR TITLE
Add fade-in sections and hover animations with reduced-motion support

### DIFF
--- a/components/Card.js
+++ b/components/Card.js
@@ -1,5 +1,6 @@
 import styles from './Card.module.css';
+import FadeInSection from './FadeInSection';
 
 export default function Card({ children }) {
-  return <section className={styles.card}>{children}</section>;
+  return <FadeInSection className={styles.card}>{children}</FadeInSection>;
 }

--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -4,4 +4,19 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   padding: var(--space-md);
   margin: var(--space-lg) 0;
+  transition: transform 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(calc(var(--space-xs) * -1));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
 }

--- a/components/FadeInSection.js
+++ b/components/FadeInSection.js
@@ -1,0 +1,21 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import theme from '../styles/theme';
+
+export default function FadeInSection({ children, ...props }) {
+  const shouldReduceMotion = useReducedMotion();
+
+  const initial = shouldReduceMotion ? {} : { opacity: 0, y: theme.spacing.sm };
+  const animate = shouldReduceMotion ? {} : { opacity: 1, y: 0 };
+
+  return (
+    <motion.section
+      initial={initial}
+      whileInView={animate}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+      {...props}
+    >
+      {children}
+    </motion.section>
+  );
+}

--- a/components/FilterBar.js
+++ b/components/FilterBar.js
@@ -1,5 +1,6 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import theme from '../styles/theme';
+import styles from './FilterBar.module.css';
 
 const categories = [
   'Featured',
@@ -10,6 +11,8 @@ const categories = [
 ];
 
 export default function FilterBar({ selectedCategory, onSelect }) {
+  const shouldReduceMotion = useReducedMotion();
+
   return (
     <div
       style={{
@@ -22,21 +25,13 @@ export default function FilterBar({ selectedCategory, onSelect }) {
         <motion.button
           key={cat}
           onClick={() => onSelect(cat)}
-          whileHover={{ scale: 1.05 }}
-          style={{
-            padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
-            border: `1px solid ${theme.colors.primary}`,
-            borderRadius: '4px',
-            background:
-              selectedCategory === cat
-                ? theme.colors.primary
-                : theme.colors.background,
-            color:
-              selectedCategory === cat
-                ? theme.colors.background
-                : theme.colors.primary,
-            cursor: 'pointer'
-          }}
+          className={`${styles.button} ${selectedCategory === cat ? styles.buttonActive : ''}`}
+          whileHover={
+            shouldReduceMotion
+              ? {}
+              : { y: `calc(-1 * ${theme.spacing.xs})` }
+          }
+          transition={{ duration: 0.2 }}
         >
           {cat}
         </motion.button>

--- a/components/FilterBar.module.css
+++ b/components/FilterBar.module.css
@@ -1,0 +1,20 @@
+.button {
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-primary);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.buttonActive {
+  background: var(--color-primary);
+  color: var(--color-background);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    transition: none;
+  }
+}

--- a/components/ServiceSection.js
+++ b/components/ServiceSection.js
@@ -1,9 +1,10 @@
 import Link from 'next/link';
 import theme from '../styles/theme';
+import FadeInSection from './FadeInSection';
 
 export default function ServiceSection({ title, text, items, ctaText, ctaHref }) {
   return (
-    <section style={{ marginTop: theme.spacing.xl }}>
+    <FadeInSection style={{ marginTop: theme.spacing.xl }}>
       <h2>{title}</h2>
       <p>{text}</p>
       <ul
@@ -23,6 +24,6 @@ export default function ServiceSection({ title, text, items, ctaText, ctaHref })
       >
         {ctaText}
       </Link>
-    </section>
+    </FadeInSection>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import HeroHeader from '../components/HeroHeader';
 import theme from '../styles/theme';
-import { motion } from 'framer-motion';
+import FadeInSection from '../components/FadeInSection';
 import Link from 'next/link';
 
 const siteUrl = 'https://alex-chesnay.com';
@@ -39,19 +39,13 @@ export default function Home() {
             Voir nos réalisations
           </Link>
         </div>
-        <motion.section
-          style={{ padding: theme.spacing.lg }}
-          initial={{ opacity: 0, y: 40 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.5 }}
-        >
+        <FadeInSection style={{ padding: theme.spacing.lg }}>
           <h1>Accueil de notre studio d'animation 3D</h1>
           <p>
             Bienvenue sur le portfolio de notre studio d'animation 3D, dédié aux
             images de synthèse et effets visuels.
           </p>
-        </motion.section>
+        </FadeInSection>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- introduce reusable `FadeInSection` using framer-motion with `prefers-reduced-motion` awareness
- add subtle token-based hover translations for cards and filter tabs, disabling transitions when motion is reduced

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689a175f76088324b12500389edf41d7