### PR TITLE
Use official Google Maps embed and update CSP

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,7 +4,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com;
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; media-src 'self' https://www.youtube.com https://player.vimeo.com; frame-src https://www.youtube.com https://player.vimeo.com https://www.google.com https://maps.googleapis.com https://maps.gstatic.com https://google.fr;
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 /index.html

--- a/contact/index.html
+++ b/contact/index.html
@@ -37,7 +37,8 @@
     <div class="content-narrow">
       <h1>Contact</h1>
       <div class="map-embed">
-        <iframe src="https://maps.google.com/maps?q=75001%20PARIS&t=&z=13&ie=UTF8&iwloc=&output=embed" loading="lazy" allowfullscreen></iframe>
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9174186333637!2d2.3364!3d48.8627!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47e671d877f6799d%3A0x8c43efed8a4f6f75!2s75001%20Paris!5e0!3m2!1sfr!2sfr!4v1716660000000!5m2!1sfr!2sfr" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <p class="map-link"><a href="https://www.google.com/maps?q=75001+Paris" target="_blank" rel="noopener">Ouvrir dans Google Maps</a></p>
       </div>
     </div>
     <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="content-narrow contact-form">
@@ -65,7 +66,7 @@
       </div>
       <div data-netlify-recaptcha="true"></div>
       <button type="submit" class="btn-primary">Envoyer</button>
-      <p class="form-message success visually-hidden">Message envoyé !</p>
+      <p class="form-message success visually-hidden">Merci, votre message a bien été envoyé.</p>
       <p class="form-message error visually-hidden">Une erreur est survenue.</p>
     </form>
   </main>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -47,7 +47,7 @@ export default function Contact() {
         body: new URLSearchParams(formData).toString(),
       });
       if (response.ok) {
-        setStatus({ type: 'success', message: 'Message envoyé !' });
+        setStatus({ type: 'success', message: 'Merci, votre message a bien été envoyé.' });
         setForm({ firstName: '', lastName: '', phone: '', email: '', message: '' });
         setRecaptchaToken(null);
         recaptchaRef.current?.reset();
@@ -169,13 +169,18 @@ export default function Contact() {
         <div className="map-wrapper">
           <div className="map-responsive">
             <iframe
-              src="https://www.google.com/maps?q=75001+Paris&output=embed"
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9174186333637!2d2.3364!3d48.8627!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47e671d877f6799d%3A0x8c43efed8a4f6f75!2s75001%20Paris!5e0!3m2!1sfr!2sfr!4v1716660000000!5m2!1sfr!2sfr"
               allowFullScreen=""
               loading="lazy"
               referrerPolicy="no-referrer-when-downgrade"
               title="Localisation 75001 Paris"
             ></iframe>
           </div>
+          <p>
+            <a href="https://www.google.com/maps?q=75001+Paris" target="_blank" rel="noopener">
+              Ouvrir dans Google Maps
+            </a>
+          </p>
           <div className="contact-details">
             <p>Adresse : 75001 Paris</p>
             <p>


### PR DESCRIPTION
## Summary
- embed Google Maps with official URL for 75001 Paris and add direct link
- improve contact form success message
- allow Google Maps domains in CSP frame-src

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a51b355d08324ac3774611910b167