### PR TITLE
Improve responsive grid layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -178,8 +178,8 @@ nav ul li.active {
 /* Bottom gallery grid */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-24);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
   margin-top: var(--space-80);
 }
 
@@ -446,6 +446,12 @@ header h1 {
     flex-direction: column;
     align-items: center;
     gap: var(--space-8);
+  }
+}
+
+@media (min-width: 481px) and (max-width: 767px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -105,8 +105,8 @@ p {
 
 .responsive-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-md);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
 }
 
 .video-wrapper {
@@ -199,8 +199,8 @@ button:focus-visible {
 /* Project gallery grid and cards */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-md);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
 }
 
 .project-card {
@@ -246,10 +246,6 @@ button:focus-visible {
 }
 
 @media (max-width: 768px) {
-  .responsive-grid {
-    grid-template-columns: 1fr;
-  }
-
   nav ul {
     flex-direction: column;
     gap: var(--space-xs);
@@ -257,5 +253,19 @@ button:focus-visible {
 
   .project-hero .hero-media {
     height: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .responsive-grid,
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 481px) and (max-width: 767px) {
+  .responsive-grid,
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }


### PR DESCRIPTION
## Summary
- adjust grid layouts to use `repeat(auto-fit,minmax(200px,1fr))` with 16px gaps
- add media queries for 1- and 2-column layouts below 768px for smoother transitions

## Testing
- `npm test`
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a670110e88324a7c9b55d05d016da