### PR TITLE
Refactor header for mobile-friendly scrollable nav

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -8,7 +8,6 @@ import projects from '../../private/projects.json' assert { type: 'json' };
 export default function Header() {
   const { asPath } = useRouter();
   const [projectsOpen, setProjectsOpen] = useState(asPath.startsWith('/projets'));
-  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <header
@@ -20,86 +19,95 @@ export default function Header() {
         padding: 'var(--space-md) 0'
       }}
     >
-      <div className={`container ${styles.inner}`}>
-        <nav
-          className={`${styles.nav} ${menuOpen ? styles.open : ''}`}
-          style={{ gap: 'var(--space-md)' }}
-        >
-          <button
-            className={styles.menuButton}
-            aria-label="Menu"
-            aria-expanded={menuOpen}
-            onClick={() => setMenuOpen(!menuOpen)}
-          >
-            ☰
-          </button>
-          <Link href="/" className={`${styles.navLink} ${asPath === '/' ? styles.active : ''}`}>Accueil</Link>
-          <details
-            className={styles.dropdown}
-            open={projectsOpen}
-            onToggle={(e) => setProjectsOpen(e.target.open)}
-          >
-            <summary
-              aria-haspopup="menu"
-              aria-expanded={projectsOpen}
-              className={`${styles.navLink} ${
-                asPath.startsWith('/projets') ? styles.active : ''
-              }`}
-            >
-              Projets
-            </summary>
-            <ul className={styles.dropdownMenu} role="menu">
-              {projects.map((project) => (
-                <li key={project.slug} role="none">
+      <div className="container">
+        <nav>
+          <div className={styles['nav-inner']}>
+            <div className={styles['nav-scroll']}>
+              <ul className={styles['main-menu']}>
+                <li>
                   <Link
-                    href={`/projets/${project.slug}`}
-                    className={`${styles.navLink} ${
-                      asPath === `/projets/${project.slug}` ? styles.active : ''
-                    }`}
-                    role="menuitem"
+                    href="/"
+                    className={`${styles.navLink} ${asPath === '/' ? styles.active : ''}`}
                   >
-                    {project.title}
+                    Accueil
                   </Link>
                 </li>
-              ))}
-            </ul>
-          </details>
-          <Link
-            href="/services/"
-            className={`${styles.navLink} ${asPath.startsWith('/services') ? styles.active : ''}`}
-          >
-            Services
-          </Link>
-          <Link
-            href="/a-propos/"
-            className={`${styles.navLink} ${asPath === '/a-propos' ? styles.active : ''}`}
-          >
-            À propos
-          </Link>
-          <Link
-            href="/blog/"
-            className={`${styles.navLink} ${asPath.startsWith('/blog') ? styles.active : ''}`}
-          >
-            Blog
-          </Link>
-          <Link
-            href="/contact/"
-            aria-current={asPath === '/contact' ? 'page' : undefined}
-            className={`${styles.navLink} ${
-              asPath === '/contact' ? styles.active : ''
-            } ${styles.contactLink}`}
-          >
-            Contact
-          </Link>
+                <li>
+                  <details
+                    className={styles.dropdown}
+                    open={projectsOpen}
+                    onToggle={(e) => setProjectsOpen(e.target.open)}
+                  >
+                    <summary
+                      aria-haspopup="menu"
+                      aria-expanded={projectsOpen}
+                      className={`${styles.navLink} ${
+                        asPath.startsWith('/projets') ? styles.active : ''
+                      }`}
+                    >
+                      Projets
+                    </summary>
+                    <ul className={styles.dropdownMenu} role="menu">
+                      {projects.map((project) => (
+                        <li key={project.slug} role="none">
+                          <Link
+                            href={`/projets/${project.slug}`}
+                            className={`${styles.navLink} ${
+                              asPath === `/projets/${project.slug}` ? styles.active : ''
+                            }`}
+                            role="menuitem"
+                          >
+                            {project.title}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                </li>
+                <li>
+                  <Link
+                    href="/services/"
+                    className={`${styles.navLink} ${
+                      asPath.startsWith('/services') ? styles.active : ''
+                    }`}
+                  >
+                    Services
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/a-propos/"
+                    className={`${styles.navLink} ${
+                      asPath === '/a-propos' ? styles.active : ''
+                    }`}
+                  >
+                    À propos
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/blog/"
+                    className={`${styles.navLink} ${
+                      asPath.startsWith('/blog') ? styles.active : ''
+                    }`}
+                  >
+                    Blog
+                  </Link>
+                </li>
+              </ul>
+            </div>
+            <Link
+              href="/contact/"
+              aria-current={asPath === '/contact' ? 'page' : undefined}
+              className={`${styles.navLink} ${styles['contact-cta']} ${
+                asPath === '/contact' ? styles.active : ''
+              }`}
+              style={{ background: theme.colors.cyan, color: theme.colors.white }}
+            >
+              Contact
+            </Link>
+          </div>
         </nav>
-        <Link
-          href="/contact/"
-          aria-current={asPath === '/contact' ? 'page' : undefined}
-          className={styles.contactButton}
-          style={{ background: theme.colors.cyan, color: theme.colors.white }}
-        >
-          Contact
-        </Link>
       </div>
     </header>
   );

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -5,37 +5,54 @@
   right: 0;
 }
 
-.inner {
+.nav-inner {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
 }
 
-.nav {
+.nav-scroll {
   flex: 1;
+  overflow-x: auto;
+}
+
+.main-menu {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-wrap: nowrap;
+  gap: var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.menuButton {
-  display: none;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
+.main-menu li {
+  flex-shrink: 0;
 }
 
-.nav a,
-.nav summary {
+.navLink {
+  background-color: var(--color-primary);
+  color: var(--color-white);
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  padding: var(--space-xs) var(--space-md);
   text-decoration: none;
-  min-height: 44px;
+  transition: opacity 0.3s ease, transform 0.3s ease;
   display: flex;
   align-items: center;
+  min-height: 44px;
   cursor: pointer;
 }
 
-.nav summary::-webkit-details-marker {
+.navLink:hover {
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+.navLink:active {
+  opacity: 0.8;
+  transform: translateY(0);
+}
+
+.navLink::-webkit-details-marker {
   display: none;
 }
 
@@ -65,65 +82,8 @@
   font-weight: bold;
 }
 
-.navLink {
-  background-color: var(--color-primary);
-  color: var(--color-white);
-  border-radius: var(--radius-sm);
-  font-weight: 700;
-  padding: var(--space-xs) var(--space-md);
-  text-decoration: none;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-}
-
-.navLink:hover {
-  opacity: 0.9;
-  transform: translateY(-2px);
-}
-
-.navLink:active {
-  opacity: 0.8;
-  transform: translateY(0);
-}
-
-.contactButton {
-  margin-left: auto;
-  padding: var(--space-xs) var(--space-md);
-  text-decoration: none;
-  border-radius: var(--radius-sm);
-  font-weight: 700;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-}
-
-.contactButton:hover {
-  opacity: 0.9;
-  transform: translateY(-2px);
-}
-
-@media (max-width: 768px) {
-  .menuButton {
-    display: flex;
-    align-items: center;
-  }
-  .nav a,
-  .nav summary {
-    display: none;
-  }
-  .open a,
-  .open summary {
-    display: flex;
-  }
-  .contactButton {
-    display: none;
-  }
-}
-
-@media (min-width: 769px) {
-  .nav {
-    justify-content: flex-start;
-  }
-
-  .contactLink {
-    display: none;
-  }
+.contact-cta {
+  margin-left: var(--space-md);
+  flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- replace hamburger navigation with always-visible links
- wrap menu in scrollable container and add contact CTA on the right
- style header for flex layout with pill buttons and horizontal scrolling

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_689bc76c6d40832487c8f2c9f3e0ef38