### PR TITLE
Fix mobile navigation layout and add baseline resets

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,6 +56,20 @@
   --max-width: 1200px;
 }
 
+@media (max-width: 768px) {
+  html {
+    -webkit-text-size-adjust: 100%;
+  }
+
+  .container {
+    padding: 0 var(--space-sm);
+  }
+
+  .project-hero .hero-media {
+    height: auto;
+  }
+}
+
 .container {
   max-width: var(--max-width);
   margin: 0 auto;
@@ -243,17 +257,6 @@ button:focus-visible {
 
 .project-card:hover .project-img {
   transform: scale(1.05);
-}
-
-@media (max-width: 768px) {
-  nav ul {
-    flex-direction: column;
-    gap: var(--space-xs);
-  }
-
-  .project-hero .hero-media {
-    height: auto;
-  }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- remove mobile rule that forced `nav ul` into a column
- add mobile reset for text-size and tighter container padding
- keep project hero media responsive in same breakpoint

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bc93a268883249e83c25c3a2dd001