### PR TITLE
refactor: unify mobile grid and card styles

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -217,13 +217,27 @@ button:focus-visible {
   gap: 16px;
 }
 
+.card,
+.project-card {
+  width: 100%;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
 .project-card {
   position: relative;
   display: block;
-  border-radius: 8px;
-  overflow: hidden;
   aspect-ratio: 16/9;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.card img,
+.project-card img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+  display: block;
 }
 
 .project-card::after {
@@ -247,28 +261,17 @@ button:focus-visible {
   transform: translateY(0);
 }
 
-.project-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-  display: block;
-}
-
-.project-card:hover .project-img {
+.project-card:hover img {
   transform: scale(1.05);
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .responsive-grid,
-  .grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (min-width: 481px) and (max-width: 767px) {
-  .responsive-grid,
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
+  .grid,
+  .projects-grid,
+  .cards {
+    grid-template-columns: 1fr !important;
+    gap: 16px;
+    padding-inline: 0;
   }
 }


### PR DESCRIPTION
## Summary
- ensure card and project-card components expand full width with consistent rounded corners and image handling
- replace multi-tier grid media queries with a single mobile rule for unified spacing

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bd5b1b0748324bad933ebe45eaf10