### PR TITLE
Reorganize footer layout and expand social icons

### DIFF
--- a/components/Layout/Footer.js
+++ b/components/Layout/Footer.js
@@ -15,7 +15,7 @@ export default function Footer() {
       <div className="container">
         <div className={styles.content}>
           <a className={styles.phone} href="tel:0768563197">0768563197</a>
-          <div className={styles.bottom}>
+          <div className={styles.center}>
             <a className={styles.email} href="mailto:alex-mennechet@outlook.fr">alex-mennechet@outlook.fr</a>
             <ul className={styles.links}>
               <li>
@@ -25,39 +25,69 @@ export default function Footer() {
                 <a href="/politique-confidentialite.html">Politique de confidentialité</a>
               </li>
             </ul>
-            <ul className={styles.social}>
-              <li>
-                <a
-                  href="https://www.instagram.com/alexchesnay"
-                  aria-label="Instagram"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  <i className="fa-brands fa-instagram" />
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.linkedin.com/in/alexchesnay"
-                  aria-label="LinkedIn"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  <i className="fa-brands fa-linkedin-in" />
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://www.artstation.com/alexchesnay"
-                  aria-label="ArtStation"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  <i className="fa-brands fa-artstation" />
-                </a>
-              </li>
-            </ul>
           </div>
+          <ul className={styles.social}>
+            <li>
+              <a
+                href="https://www.instagram.com/alexchesnay"
+                aria-label="Instagram"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-instagram" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.linkedin.com/in/alexchesnay"
+                aria-label="LinkedIn"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-linkedin-in" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.artstation.com/alexchesnay"
+                aria-label="ArtStation"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-artstation" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.facebook.com/alexchesnay"
+                aria-label="Facebook"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-facebook-f" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://vimeo.com/alexchesnay"
+                aria-label="Vimeo"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-vimeo-v" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://twitter.com/alexchesnay"
+                aria-label="X (formerly Twitter)"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-x-twitter" />
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </footer>

--- a/components/Layout/Footer.module.css
+++ b/components/Layout/Footer.module.css
@@ -8,9 +8,10 @@
   flex-direction: column;
   align-items: center;
   gap: var(--space-xs);
+  width: 100%;
 }
 
-.bottom {
+.center {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -41,4 +42,16 @@
   color: inherit;
   position: relative;
   z-index: 1;
+}
+
+@media (min-width: 768px) {
+  .content {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .center {
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure footer into phone, center block, and social links
- add Facebook, Vimeo, and X social icons
- tweak footer styles for responsive alignment

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689be06b20d08324bb258708c723033a