### PR TITLE
Add hero slider and homepage sections

### DIFF
--- a/components/HeroHeader.js
+++ b/components/HeroHeader.js
@@ -1,31 +1,29 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
 import theme from '../styles/theme';
 
 export default function HeroHeader({
   title = "Studio d'animation 3D – Mon Portfolio",
   baseline,
-  backgroundImage = '/assets/images/PAGES_0_Couverture.jpg'
+  images = ['/assets/images/PAGES_0_Couverture.jpg']
 }) {
-  const ref = useRef(null);
+  const [index, setIndex] = useState(0);
 
   useEffect(() => {
-    const onScroll = () => {
-      if (ref.current) {
-        const offset = window.pageYOffset;
-        ref.current.style.backgroundPositionY = `${offset * 0.5}px`;
-      }
-    };
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+    if (images.length > 1) {
+      const interval = setInterval(
+        () => setIndex((i) => (i + 1) % images.length),
+        5000
+      );
+      return () => clearInterval(interval);
+    }
+  }, [images.length]);
 
   return (
     <header
-      ref={ref}
       style={{
-        backgroundImage: `url(${backgroundImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
+        position: 'relative',
         height: '60vh',
         display: 'flex',
         flexDirection: 'column',
@@ -34,13 +32,42 @@ export default function HeroHeader({
         textAlign: 'center',
         color: theme.colors.primary,
         fontFamily: theme.fonts.heading,
-        marginBottom: theme.spacing.lg
+        marginBottom: theme.spacing.lg,
+        overflow: 'hidden'
       }}
     >
+      {images.map((src, i) => (
+        <Image
+          key={src}
+          src={src}
+          alt=""
+          fill
+          priority={i === 0}
+          loading="lazy"
+          style={{
+            objectFit: 'cover',
+            zIndex: -1,
+            opacity: i === index ? 1 : 0,
+            transition: 'opacity 1s ease-in-out'
+          }}
+        />
+      ))}
       <h1>{title}</h1>
       {baseline && (
         <p style={{ fontFamily: theme.fonts.body }}>{baseline}</p>
       )}
+      <div style={{ marginTop: theme.spacing.md }}>
+        <Link href="/projets/" className="btn-primary">
+          Voir nos réalisations
+        </Link>
+        <Link
+          href="/contact/"
+          className="btn-primary"
+          style={{ marginLeft: theme.spacing.md }}
+        >
+          Contact
+        </Link>
+      </div>
     </header>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import HeroHeader from '../components/HeroHeader';
 import theme from '../styles/theme';
 import FadeInSection from '../components/FadeInSection';
 import Link from 'next/link';
+import Image from 'next/image';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -30,15 +31,14 @@ export default function Home() {
         <link rel="canonical" href={url} />
       </Head>
       <main>
-        <HeroHeader />
-        <div style={{ textAlign: 'center', marginBottom: theme.spacing.lg }}>
-          <Link href="/contact/" className="contact-button">
-            Contactez-nous
-          </Link>
-          <Link href="/projets/" className="contact-button" style={{ marginLeft: theme.spacing.md }}>
-            Voir nos réalisations
-          </Link>
-        </div>
+        <HeroHeader
+          baseline="Spécialiste 3D, VFX et réalité virtuelle"
+          images={[
+            '/assets/images/PAGES_0_Couverture.jpg',
+            '/assets/images/MENNECHET_Alex_Cognac_1.jpg',
+            '/assets/images/MENNECHET_Alex_Cognac_2.jpg'
+          ]}
+        />
         <FadeInSection style={{ padding: theme.spacing.lg }}>
           <h1>Accueil de notre studio d'animation 3D</h1>
           <p>
@@ -46,6 +46,102 @@ export default function Home() {
             images de synthèse et effets visuels.
           </p>
         </FadeInSection>
+
+        <section style={{ padding: theme.spacing.lg }}>
+          <h2>En vedette</h2>
+          <div className="responsive-grid">
+            <Image
+              src="/assets/images/MENNECHET_Alex_Cognac_1.jpg"
+              alt="Projet 1"
+              width={400}
+              height={225}
+              loading="lazy"
+            />
+            <Image
+              src="/assets/images/MENNECHET_Alex_Cognac_2.jpg"
+              alt="Projet 2"
+              width={400}
+              height={225}
+              loading="lazy"
+            />
+            <Image
+              src="/assets/images/MENNECHET_Alex_Cognac_3.jpg"
+              alt="Projet 3"
+              width={400}
+              height={225}
+              loading="lazy"
+            />
+          </div>
+        </section>
+
+        <section style={{ padding: theme.spacing.lg, backgroundColor: theme.colors.grey100 }}>
+          <h2>Catégories</h2>
+          <div className="responsive-grid">
+            <div style={{ textAlign: 'center' }}>
+              <Image
+                src="/assets/images/placeholder2.png"
+                alt="Animation 3D"
+                width={300}
+                height={200}
+                loading="lazy"
+              />
+              <p>Animation 3D</p>
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <Image
+                src="/assets/images/placeholder3.png"
+                alt="Effets visuels"
+                width={300}
+                height={200}
+                loading="lazy"
+              />
+              <p>Effets visuels</p>
+            </div>
+            <div style={{ textAlign: 'center' }}>
+              <Image
+                src="/assets/images/MontreMaisonEclatIA.jpg"
+                alt="Réalité virtuelle"
+                width={300}
+                height={200}
+                loading="lazy"
+              />
+              <p>Réalité virtuelle</p>
+            </div>
+          </div>
+        </section>
+
+        <section style={{ padding: theme.spacing.lg }}>
+          <h2>Extrait blog</h2>
+          <div className="responsive-grid">
+            <article>
+              <Image
+                src="/assets/images/ProjetGateauxRendu1.jpg"
+                alt="Article de blog"
+                width={400}
+                height={225}
+                loading="lazy"
+              />
+              <h3>Créer des textures réalistes</h3>
+              <p>Découvrez nos conseils pour des rendus gourmands.</p>
+              <Link href="/blog">Lire plus</Link>
+            </article>
+          </div>
+        </section>
+
+        <section style={{ padding: theme.spacing.lg, textAlign: 'center', backgroundColor: theme.colors.grey200 }}>
+          <Image
+            src="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg"
+            alt="Contact"
+            width={600}
+            height={338}
+            loading="lazy"
+          />
+          <h2>Prêt à démarrer votre projet ?</h2>
+          <p>Contactez notre studio pour discuter de vos besoins.</p>
+          <Link href="/contact/" className="btn-primary">
+            Contact
+          </Link>
+        </section>
       </main>
     </>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -98,12 +98,12 @@ p {
 }
 
 h1 {
-  font-size: clamp(2.5rem, 5vw + 1rem, 4rem);
+  font-size: clamp(2rem, 5vw + 1rem, 3.5rem);
   line-height: var(--lh-tight);
 }
 
 h2 {
-  font-size: clamp(2rem, 4vw + 0.5rem, 3rem);
+  font-size: clamp(1.5rem, 4vw + 0.5rem, 2.5rem);
   line-height: var(--lh-tight);
 }
 


### PR DESCRIPTION
## Summary
- add baseline, CTA buttons and lazy-loaded slider to hero header
- build featured, category, blog preview and contact sections on home page
- tweak responsive heading styles to avoid mobile overflow

## Testing
- `npm test`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_689be1f0c3c08324aa6664c6ab6380f5