### PR TITLE
Use Leaflet for contact page map

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -14,6 +14,7 @@
   <link rel="canonical" href="https://alexchesnay.com/contact/" />
   <title>Contact - Alex Chesnay</title>
   <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
 </head>
@@ -41,8 +42,8 @@
     <div class="content-narrow">
       <h1 class="text-center">Contact</h1>
       <div class="map-embed">
-        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2624.9174186333637!2d2.3364!3d48.8627!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47e671d877f6799d%3A0x8c43efed8a4f6f75!2s75001%20Paris!5e0!3m2!1sfr!2sfr!4v1716660000000!5m2!1sfr!2sfr" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
-        <p class="map-link text-left"><a href="https://www.google.com/maps?q=75001+Paris" target="_blank" rel="noopener" class="btn-primary">Ouvrir dans Google Maps</a></p>
+        <div id="map" style="width:100%;height:100%;"></div>
+        <p class="map-link text-left"><a href="https://www.openstreetmap.org/?mlat=48.8627&mlon=2.3364#map=13/48.8627/2.3364" target="_blank" rel="noopener" class="btn-primary">Ouvrir dans OpenStreetMap</a></p>
       </div>
       <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="contact-form">
         <input type="hidden" name="form-name" value="contact" />
@@ -108,6 +109,16 @@
     </div>
   </div>
 </footer>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const map = L.map('map').setView([48.8627, 2.3364], 13);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+      L.marker([48.8627, 2.3364]).addTo(map);
+    });
+  </script>
   <script src="/js/contact.js"></script>
   <script src="/js/script.min.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- remove Google Maps iframe and embed Leaflet map
- load OpenStreetMap tiles and add fallback link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7e0caf488324a89324d91e88dc72