### PR TITLE
Add global topbar with RSS/contact links and social icons

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import styles from './Header.module.css';
 import theme from '../../styles/theme';
 import projects from '../../private/projects.json' assert { type: 'json' };
+import Topbar from './Topbar';
 
 export default function Header() {
   const { asPath } = useRouter();
@@ -28,16 +29,18 @@ export default function Header() {
   }, []);
 
   return (
-    <header
-      className={styles.header}
-      style={{
-        background: theme.colors.background,
-        borderBottom: `1px solid ${theme.colors.text}`,
-        color: theme.colors.text,
-        padding: 'var(--space-md) 0'
-      }}
-    >
-      <div className="container">
+    <>
+      <Topbar />
+      <header
+        className={styles.header}
+        style={{
+          background: theme.colors.background,
+          borderBottom: `1px solid ${theme.colors.text}`,
+          color: theme.colors.text,
+          padding: 'var(--space-md) 0'
+        }}
+      >
+        <div className="container">
         <nav>
           <div className={styles['nav-inner']}>
             <button
@@ -136,5 +139,6 @@ export default function Header() {
         </nav>
       </div>
     </header>
+  </>
   );
 }

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   position: fixed;
-  top: 0;
+  top: 40px;
   left: 0;
   right: 0;
 }

--- a/components/Layout/Topbar.js
+++ b/components/Layout/Topbar.js
@@ -1,0 +1,90 @@
+import Link from 'next/link';
+import styles from './Topbar.module.css';
+import theme from '../../styles/theme';
+
+export default function Topbar() {
+  return (
+    <div
+      className={styles.topbar}
+      style={{
+        background: theme.colors.text,
+        color: theme.colors.white
+      }}
+    >
+      <div className="container">
+        <div className={styles.inner}>
+          <ul className={styles.links}>
+            <li>
+              <a href="/rss.xml">RSS</a>
+            </li>
+            <li>
+              <Link href="/contact/">Contact</Link>
+            </li>
+          </ul>
+          <ul className={styles.social} aria-label="R\u00e9seaux sociaux">
+            <li>
+              <a
+                href="https://www.instagram.com/alexchesnay"
+                aria-label="Instagram"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-instagram" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.linkedin.com/in/alexchesnay"
+                aria-label="LinkedIn"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-linkedin-in" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.artstation.com/alexchesnay"
+                aria-label="ArtStation"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-artstation" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.facebook.com/alexchesnay"
+                aria-label="Facebook"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-facebook-f" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://vimeo.com/alexchesnay"
+                aria-label="Vimeo"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-vimeo-v" />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://twitter.com/alexchesnay"
+                aria-label="X (formerly Twitter)"
+                target="_blank"
+                rel="noopener"
+              >
+                <i className="fa-brands fa-x-twitter" />
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Layout/Topbar.module.css
+++ b/components/Layout/Topbar.module.css
@@ -1,0 +1,44 @@
+.topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  height: 40px;
+}
+
+.inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+}
+
+.links {
+  display: flex;
+  list-style: none;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+}
+
+.links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.social {
+  display: flex;
+  list-style: none;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+}
+
+.social a {
+  color: inherit;
+}
+
+.social i {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- add reusable Topbar component with RSS + contact links and social icons
- position topbar above header and adjust header offset
- display topbar on every page via Header import

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689cbeb40480832485ab4d875f3f9fb4