### PR TITLE
Align logo and navigation in header

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -43,6 +43,13 @@ export default function Header() {
         <div className="container">
         <nav>
           <div className={styles['nav-inner']}>
+            <Link
+              href="/"
+              aria-current={asPath === '/' ? 'page' : undefined}
+              className={styles.logo}
+            >
+              Alex Chesnay
+            </Link>
             <button
               className={`${styles.burger} ${menuOpen ? styles.open : ''}`}
               aria-label={menuOpen ? 'Fermer le menu' : 'Ouvrir le menu'}

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -10,8 +10,17 @@
   align-items: center;
 }
 
+.logo {
+  margin-right: auto;
+  font-weight: 700;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+}
+
 .nav-scroll {
-  flex: 1;
+  flex: none;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
## Summary
- Place logo link before navigation menu and retain aria attributes
- Use flexbox to align logo left and menu items right

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2deb99883248cf44e4a412becaf