### PR TITLE
Add dropdown menus for store and blog

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -4,11 +4,25 @@ import { useState, useEffect } from 'react';
 import styles from './Header.module.css';
 import theme from '../../styles/theme';
 import projects from '../../private/projects.json' assert { type: 'json' };
+
+const storeMenu = [
+  { slug: '', title: 'Boutique' },
+  { slug: 'prints', title: 'Prints' },
+  { slug: 'downloads', title: 'Downloads' }
+];
+
+const blogMenu = [
+  { slug: '', title: 'Tous les articles' },
+  { slug: 'news', title: 'Actualités' },
+  { slug: 'tutorials', title: 'Tutoriels' }
+];
 import Topbar from './Topbar';
 
 export default function Header() {
   const { asPath } = useRouter();
   const [projectsOpen, setProjectsOpen] = useState(asPath.startsWith('/projets'));
+  const [storeOpen, setStoreOpen] = useState(asPath.startsWith('/store'));
+  const [blogOpen, setBlogOpen] = useState(asPath.startsWith('/blog'));
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
@@ -121,14 +135,74 @@ export default function Header() {
                   </Link>
                 </li>
                 <li>
-                  <Link
-                    href="/blog/"
-                    className={`${styles.navLink} ${
-                      asPath.startsWith('/blog') ? styles.active : ''
-                    }`}
+                  <details
+                    className={styles.dropdown}
+                    open={storeOpen}
+                    onToggle={(e) => setStoreOpen(e.target.open)}
                   >
-                    Blog
-                  </Link>
+                    <summary
+                      aria-haspopup="menu"
+                      aria-expanded={storeOpen}
+                      className={`${styles.navLink} ${
+                        asPath.startsWith('/store') ? styles.active : ''
+                      }`}
+                    >
+                      Store
+                    </summary>
+                    <ul className={styles.dropdownMenu} role="menu">
+                      {storeMenu.map((item) => {
+                        const path = item.slug ? `/store/${item.slug}` : '/store';
+                        return (
+                          <li key={item.slug || 'index'} role="none">
+                            <Link
+                              href={item.slug ? `/store/${item.slug}/` : '/store/'}
+                              className={`${styles.navLink} ${
+                                asPath === path ? styles.active : ''
+                              }`}
+                              role="menuitem"
+                            >
+                              {item.title}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </details>
+                </li>
+                <li>
+                  <details
+                    className={styles.dropdown}
+                    open={blogOpen}
+                    onToggle={(e) => setBlogOpen(e.target.open)}
+                  >
+                    <summary
+                      aria-haspopup="menu"
+                      aria-expanded={blogOpen}
+                      className={`${styles.navLink} ${
+                        asPath.startsWith('/blog') ? styles.active : ''
+                      }`}
+                    >
+                      Blog
+                    </summary>
+                    <ul className={styles.dropdownMenu} role="menu">
+                      {blogMenu.map((item) => {
+                        const path = item.slug ? `/blog/${item.slug}` : '/blog';
+                        return (
+                          <li key={item.slug || 'index'} role="none">
+                            <Link
+                              href={item.slug ? `/blog/${item.slug}/` : '/blog/'}
+                              className={`${styles.navLink} ${
+                                asPath === path ? styles.active : ''
+                              }`}
+                              role="menuitem"
+                            >
+                              {item.title}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </details>
                 </li>
               </ul>
             </div>

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -70,7 +70,7 @@
 }
 
 .dropdownMenu {
-  display: none;
+  display: flex;
   flex-direction: column;
   position: absolute;
   top: 100%;
@@ -81,10 +81,21 @@
   background: inherit;
   border: 1px solid currentColor;
   z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
+
+.dropdown:hover .dropdownMenu,
+.dropdown:focus-within .dropdownMenu,
 .dropdown[open] .dropdownMenu {
-  display: flex;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 
 .active {

--- a/pages/blog/news.js
+++ b/pages/blog/news.js
@@ -1,0 +1,8 @@
+export default function BlogNews() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <h1>Actualités</h1>
+      <p>Les actualités seront publiées ici.</p>
+    </main>
+  );
+}

--- a/pages/blog/tutorials.js
+++ b/pages/blog/tutorials.js
@@ -1,0 +1,8 @@
+export default function BlogTutorials() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <h1>Tutoriels</h1>
+      <p>Les tutoriels arriveront prochainement.</p>
+    </main>
+  );
+}

--- a/pages/store/downloads.js
+++ b/pages/store/downloads.js
@@ -1,0 +1,8 @@
+export default function StoreDownloads() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <h1>Downloads</h1>
+      <p>Les fichiers téléchargeables seront disponibles ici.</p>
+    </main>
+  );
+}

--- a/pages/store/index.js
+++ b/pages/store/index.js
@@ -1,0 +1,8 @@
+export default function StoreIndex() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <h1>Boutique</h1>
+      <p>Contenu de la boutique à venir.</p>
+    </main>
+  );
+}

--- a/pages/store/prints.js
+++ b/pages/store/prints.js
@@ -1,0 +1,8 @@
+export default function StorePrints() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <h1>Prints</h1>
+      <p>Cette page présentera les impressions disponibles.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace Store and Blog links with dropdown menus
- show dropdowns on hover/focus with smooth transitions
- add placeholder pages for store sections and blog categories

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689ccb20c6588324b1da98f563e7bb10