### PR TITLE
Make header sticky with scroll shadow

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -24,6 +24,7 @@ export default function Header() {
   const [storeOpen, setStoreOpen] = useState(asPath.startsWith('/store'));
   const [blogOpen, setBlogOpen] = useState(asPath.startsWith('/blog'));
   const [menuOpen, setMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = menuOpen ? 'hidden' : '';
@@ -42,11 +43,20 @@ export default function Header() {
     return () => document.removeEventListener('keydown', handleKey);
   }, []);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 0);
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   return (
     <>
       <Topbar />
       <header
-        className={styles.header}
+        className={`${styles.header} ${scrolled ? styles.scrolled : ''}`}
         style={{
           background: theme.colors.background,
           borderBottom: `1px solid ${theme.colors.text}`,

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -1,8 +1,14 @@
 .header {
-  position: fixed;
-  top: 40px;
+  position: sticky;
+  top: 0;
   left: 0;
   right: 0;
+  box-shadow: none;
+  transition: box-shadow 0.3s ease;
+}
+
+.scrolled {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .nav-inner {


### PR DESCRIPTION
## Summary
- make `Header` position sticky at top with scroll-triggered shadow
- add scroll listener hook to toggle `scrolled` class

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689cd8a3823883249d7a15cb8bbc260d