### PR TITLE
Add breadcrumb navigation across pages

### DIFF
--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import HeroHeader from '../components/HeroHeader';
 import Card from '../components/Card';
 import theme from '../styles/theme';
+import Breadcrumb from '../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -30,6 +31,12 @@ export default function APropos() {
         <link rel="canonical" href={url} />
       </Head>
       <main>
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'À propos' }
+          ]}
+        />
         <HeroHeader title="À propos" baseline="Découvrez notre studio" />
         <motion.div
           style={{ padding: theme.spacing.lg }}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import theme from '../../styles/theme';
 import BlogCard from '../../components/BlogCard';
 import posts from '../../private/blog.json' assert { type: 'json' };
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -40,6 +41,12 @@ export default function Blog() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Blog' }
+          ]}
+        />
         <h1>Blog du studio d'animation 3D</h1>
         <div className="responsive-grid">
           {posts.slice(0, visibleCount).map((post) => (

--- a/pages/blog/news.js
+++ b/pages/blog/news.js
@@ -1,6 +1,15 @@
+import Breadcrumb from '../../components/Breadcrumb';
+
 export default function BlogNews() {
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Blog', href: '/blog' },
+          { label: 'Actualités' }
+        ]}
+      />
       <h1>Actualités</h1>
       <p>Les actualités seront publiées ici.</p>
     </main>

--- a/pages/blog/tutorials.js
+++ b/pages/blog/tutorials.js
@@ -1,6 +1,15 @@
+import Breadcrumb from '../../components/Breadcrumb';
+
 export default function BlogTutorials() {
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Blog', href: '/blog' },
+          { label: 'Tutoriels' }
+        ]}
+      />
       <h1>Tutoriels</h1>
       <p>Les tutoriels arriveront prochainement.</p>
     </main>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -3,6 +3,7 @@ import { useState, useRef } from 'react';
 import { motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
 import theme from '../styles/theme';
+import Breadcrumb from '../components/Breadcrumb';
 
 const ReCAPTCHA = dynamic(() => import('react-google-recaptcha'), { ssr: false });
 
@@ -82,6 +83,12 @@ export default function Contact() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Contact' }
+          ]}
+        />
         <h1>Contactez notre studio d'animation 3D</h1>
         <form
           onSubmit={handleSubmit}

--- a/pages/credits.js
+++ b/pages/credits.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../styles/theme';
+import Breadcrumb from '../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -51,6 +52,12 @@ export default function Credits() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Crédits' }
+          ]}
+        />
         <h1>Crédits</h1>
         <p>Liste des images utilisées sur ce site avec leur source et licence.</p>
         <ul>

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../styles/theme';
+import Breadcrumb from '../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -33,6 +34,12 @@ export default function MentionsLegales() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Mentions légales' }
+          ]}
+        />
         <h1>Mentions légales</h1>
         <section style={{ margin: `${theme.spacing.lg} 0` }}>
           <h2>Éditeur du site</h2>

--- a/pages/politique-de-confidentialite.js
+++ b/pages/politique-de-confidentialite.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../styles/theme';
+import Breadcrumb from '../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -33,6 +34,12 @@ export default function PolitiqueDeConfidentialite() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Politique de confidentialité' }
+          ]}
+        />
         <h1>Politique de confidentialité</h1>
         <section style={{ margin: `${theme.spacing.lg} 0` }}>
           <h2>Données collectées</h2>

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { useState } from 'react';
 import theme from '../../styles/theme';
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 const imageSizes = {
@@ -45,6 +46,12 @@ export default function Projects({ projects }) {
         <link rel="canonical" href={url} />
       </Head>
       <main style={{ padding: theme.spacing.lg }}>
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Projets' }
+          ]}
+        />
         <h1>Galerie de notre studio d'animation 3D</h1>
         <nav
           className="project-filters"

--- a/pages/services/animation.js
+++ b/pages/services/animation.js
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../../styles/theme';
 import ServiceSection from '../../components/ServiceSection';
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -34,6 +35,13 @@ export default function Animation() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Services', href: '/services' },
+            { label: 'Animation' }
+          ]}
+        />
         <h1>Animation</h1>
         <p>
           Nous produisons des animations fluides pour le cinéma, la publicité ou

--- a/pages/services/index.js
+++ b/pages/services/index.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import theme from '../../styles/theme';
 import ServiceSection from '../../components/ServiceSection';
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -35,6 +36,12 @@ export default function Services() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Services' }
+          ]}
+        />
         <h1>Nos services</h1>
         <ServiceSection
           title="Prestations disponibles"

--- a/pages/services/modelisation.js
+++ b/pages/services/modelisation.js
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../../styles/theme';
 import ServiceSection from '../../components/ServiceSection';
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -34,6 +35,13 @@ export default function Modelisation() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Services', href: '/services' },
+            { label: 'Modélisation' }
+          ]}
+        />
         <h1>Modélisation</h1>
         <p>
           Nous réalisons des modèles 3D précis et optimisés pour vos besoins,

--- a/pages/services/vfx.js
+++ b/pages/services/vfx.js
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import { motion } from 'framer-motion';
 import theme from '../../styles/theme';
 import ServiceSection from '../../components/ServiceSection';
+import Breadcrumb from '../../components/Breadcrumb';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -34,6 +35,13 @@ export default function VFX() {
         viewport={{ once: true }}
         transition={{ duration: 0.5 }}
       >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Services', href: '/services' },
+            { label: 'VFX' }
+          ]}
+        />
         <h1>VFX</h1>
         <p>
           Nous concevons des effets visuels saisissants pour renforcer l'impact

--- a/pages/store/downloads.js
+++ b/pages/store/downloads.js
@@ -1,6 +1,15 @@
+import Breadcrumb from '../../components/Breadcrumb';
+
 export default function StoreDownloads() {
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Boutique', href: '/store' },
+          { label: 'Downloads' }
+        ]}
+      />
       <h1>Downloads</h1>
       <p>Les fichiers téléchargeables seront disponibles ici.</p>
     </main>

--- a/pages/store/index.js
+++ b/pages/store/index.js
@@ -1,6 +1,14 @@
+import Breadcrumb from '../../components/Breadcrumb';
+
 export default function StoreIndex() {
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Boutique' }
+        ]}
+      />
       <h1>Boutique</h1>
       <p>Contenu de la boutique à venir.</p>
     </main>

--- a/pages/store/prints.js
+++ b/pages/store/prints.js
@@ -1,6 +1,15 @@
+import Breadcrumb from '../../components/Breadcrumb';
+
 export default function StorePrints() {
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Boutique', href: '/store' },
+          { label: 'Prints' }
+        ]}
+      />
       <h1>Prints</h1>
       <p>Cette page présentera les impressions disponibles.</p>
     </main>


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to blog, contact, services, store and other non-home pages
- provide page-specific breadcrumb items for hierarchical navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cda6e5f24832496fb0f3ec84fe6de