### PR TITLE
Add alt text support to HeroHeader images

### DIFF
--- a/components/HeroHeader.js
+++ b/components/HeroHeader.js
@@ -6,7 +6,12 @@ import theme from '../styles/theme';
 export default function HeroHeader({
   title = "Studio d'animation 3D – Mon Portfolio",
   baseline,
-  images = ['/assets/images/PAGES_0_Couverture.jpg']
+  images = [
+    {
+      src: '/assets/images/PAGES_0_Couverture.jpg',
+      alt: 'Image de couverture du portfolio'
+    }
+  ]
 }) {
   const [index, setIndex] = useState(0);
 
@@ -36,11 +41,11 @@ export default function HeroHeader({
         overflow: 'hidden'
       }}
     >
-      {images.map((src, i) => (
+      {images.map((image, i) => (
         <Image
-          key={src}
-          src={src}
-          alt=""
+          key={image.src}
+          src={image.src}
+          alt={image.alt}
           fill
           priority={i === 0}
           loading="lazy"

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -37,7 +37,16 @@ export default function APropos() {
             { label: 'À propos' }
           ]}
         />
-        <HeroHeader title="À propos" baseline="Découvrez notre studio" />
+        <HeroHeader
+          title="À propos"
+          baseline="Découvrez notre studio"
+          images={[
+            {
+              src: '/assets/images/PAGES_0_Couverture.jpg',
+              alt: 'Visuel de couverture du portfolio 3D'
+            }
+          ]}
+        />
         <motion.div
           style={{ padding: theme.spacing.lg }}
           initial={{ opacity: 0, y: 40 }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,9 +34,18 @@ export default function Home() {
         <HeroHeader
           baseline="Spécialiste 3D, VFX et réalité virtuelle"
           images={[
-            '/assets/images/PAGES_0_Couverture.jpg',
-            '/assets/images/MENNECHET_Alex_Cognac_1.jpg',
-            '/assets/images/MENNECHET_Alex_Cognac_2.jpg'
+            {
+              src: '/assets/images/PAGES_0_Couverture.jpg',
+              alt: 'Visuel de couverture du portfolio 3D'
+            },
+            {
+              src: '/assets/images/MENNECHET_Alex_Cognac_1.jpg',
+              alt: 'Bouteille de cognac en 3D - vue 1'
+            },
+            {
+              src: '/assets/images/MENNECHET_Alex_Cognac_2.jpg',
+              alt: 'Bouteille de cognac en 3D - vue 2'
+            }
           ]}
         />
         <FadeInSection style={{ padding: theme.spacing.lg }}>


### PR DESCRIPTION
## Summary
- allow `HeroHeader` to accept image objects with descriptive `alt` text
- update home and about pages to pass images with alt descriptions

## Testing
- `npm test`
- `npm run lint` *(fails: requests ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689cde80b80c832488cd76e95fab40a7