### PR TITLE
Use clamp-based min-height for HeroHeader

### DIFF
--- a/components/HeroHeader.js
+++ b/components/HeroHeader.js
@@ -29,7 +29,7 @@ export default function HeroHeader({
     <header
       style={{
         position: 'relative',
-        height: '60vh',
+        minHeight: 'clamp(400px, 60vh, 600px)',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',


### PR DESCRIPTION
## Summary
- replace fixed HeroHeader height with clamp-based minHeight for responsive sizing

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfe63d108324a6b4c0e169f85ecd