### PR TITLE
Use explicit grid breakpoints instead of auto-fit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -203,7 +203,7 @@ nav ul li.active > a {
 .grid,
 .responsive-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
 }
 
@@ -211,17 +211,17 @@ nav ul li.active > a {
   margin-top: var(--space-80);
 }
 
-@media (max-width: 480px) {
-  .grid,
-  .responsive-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (min-width: 481px) and (max-width: 767px) {
+@media (min-width: 768px) and (max-width: 1199px) {
   .grid,
   .responsive-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .grid,
+  .responsive-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 
@@ -761,8 +761,20 @@ header h1 {
 .card-grid {
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: 1fr;
   margin: 0 auto;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  .card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .map-embed {
@@ -836,7 +848,19 @@ header h1 {
 .gallery-grid {
   display: grid;
   gap: var(--space-16);
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  .gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .gallery-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .gallery-grid img {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -132,8 +132,20 @@ p {
 
 .responsive-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  .responsive-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .responsive-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .video-wrapper {
@@ -226,8 +238,20 @@ button:focus-visible {
 /* Project gallery grid and cards */
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: 1fr;
   gap: 16px;
+}
+
+@media (min-width: 768px) and (max-width: 1199px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .card,


### PR DESCRIPTION
## Summary
- replace auto-fit grids with fixed breakpoints in CSS and global styles
- ensure grids expand to 2 and 3 columns at 768px and 1200px

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689ceafd7a6c83249de4f5aca1fc6922