### PR TITLE
Move project pages to 'projets' directory

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -3,7 +3,7 @@
 /services.html /services/ 301
 /a-propos.html /a-propos/ 301
 /work /projets/ 301
-/work/ /projets/ 301
+/work/* /projets/:splat 301
 /projects /projets/ 301
 /mentions-legales.html /mentions-legales 301
 /politique-confidentialite.html /politique-de-confidentialite 301

--- a/index.html
+++ b/index.html
@@ -93,13 +93,13 @@
     <section id="projects" class="project-gallery">
       <h2 class="visually-hidden">Galerie des projets</h2>
       <div class="grid">
-        <a class="project-card" href="/work/project1.html" data-title="Project 1 — Rendu 3D" data-category="Animation 3D">
+        <a class="project-card" href="/projets/project1.html" data-title="Project 1 — Rendu 3D" data-category="Animation 3D">
             <img class="project-img" src="/assets/images/PAGES_0_Couverture.jpg" srcset="/assets/images/PAGES_0_Couverture.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – couverture du magazine PAGES" loading="lazy" decoding="async" width="3508" height="2480" />
         </a>
-        <a class="project-card" href="/work/project2.html" data-title="Project 2 — Visuel conceptuel" data-category="Animation 2D">
+        <a class="project-card" href="/projets/project2.html" data-title="Project 2 — Visuel conceptuel" data-category="Animation 2D">
             <img class="project-img" src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project3.html" data-title="Project 3 — Visuel conceptuel" data-category="VFX">
+        <a class="project-card" href="/projets/project3.html" data-title="Project 3 — Visuel conceptuel" data-category="VFX">
             <img class="project-img" src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
         </a>
       </div>

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -16,7 +16,7 @@ const imageSizes = {
 };
 
 export default function Project({ project, prev, next }) {
-  const url = `${siteUrl}/projets/${project.slug}`;
+  const url = `${siteUrl}/projets/${project.slug}.html`;
   const image = `${siteUrl}${project.images[0]}`;
   const title = `${project.title} - Projet - Alex Chesnay`;
   const description = project.description;
@@ -135,7 +135,7 @@ export default function Project({ project, prev, next }) {
           {prev ? (
             <Link
               className="prev"
-              href={`/projets/${prev.slug}`}
+              href={`/projets/${prev.slug}.html`}
               aria-label="Projet précédent"
             >
               Projet précédent
@@ -146,7 +146,7 @@ export default function Project({ project, prev, next }) {
           {next ? (
             <Link
               className="next"
-              href={`/projets/${next.slug}`}
+              href={`/projets/${next.slug}.html`}
               aria-label="Projet suivant"
             >
               Projet suivant

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -95,7 +95,7 @@ export default function Projects({ projects }) {
               return (
                 <Link
                   key={p.slug}
-                  href={`/projects/${p.slug}`}
+                    href={`/projets/${p.slug}.html`}
                   className="project-card"
                   data-category={p.category}
                   data-title={p.title}

--- a/portfolio.html
+++ b/portfolio.html
@@ -53,31 +53,31 @@
     <section id="projects" class="project-gallery">
       <h2 class="visually-hidden">Galerie des projets</h2>
       <div class="grid">
-        <a class="project-card" href="/work/project1.html" data-category="3D">
+        <a class="project-card" href="/projets/project1.html" data-category="3D">
             <img class="project-img" src="/assets/images/PAGES_0_Couverture.jpg" srcset="/assets/images/PAGES_0_Couverture.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – couverture du magazine PAGES" loading="lazy" decoding="async" width="3508" height="2480" />
         </a>
-        <a class="project-card" href="/work/project2.html" data-category="2D">
+        <a class="project-card" href="/projets/project2.html" data-category="2D">
             <img class="project-img" src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project3.html" data-category="VFX">
+        <a class="project-card" href="/projets/project3.html" data-category="VFX">
             <img class="project-img" src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
         </a>
-        <a class="project-card" href="/work/project4.html" data-category="VR">
+        <a class="project-card" href="/projets/project4.html" data-category="VR">
             <img class="project-img" src="/assets/images/project4.png" srcset="/assets/images/project4.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project5.html" data-category="3D">
+        <a class="project-card" href="/projets/project5.html" data-category="3D">
             <img class="project-img" src="/assets/images/project5.png" srcset="/assets/images/project5.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project6.html" data-category="2D">
+        <a class="project-card" href="/projets/project6.html" data-category="2D">
             <img class="project-img" src="/assets/images/project6.png" srcset="/assets/images/project6.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
         </a>
-        <a class="project-card" href="/work/project7.html" data-category="VFX">
+        <a class="project-card" href="/projets/project7.html" data-category="VFX">
             <img class="project-img" src="/assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="/assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – bouteille de cognac" loading="lazy" decoding="async" width="6254" height="3498" />
         </a>
-        <a class="project-card" href="/work/project8.html" data-category="3D">
+        <a class="project-card" href="/projets/project8.html" data-category="3D">
             <img class="project-img" src="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – flacon de parfum" loading="lazy" decoding="async" width="3104" height="2160" />
         </a>
-        <a class="project-card" href="/work/project9.html" data-category="VR">
+        <a class="project-card" href="/projets/project9.html" data-category="VR">
             <img class="project-img" src="/assets/images/MontreMaisonEclatIA.jpg" srcset="/assets/images/MontreMaisonEclatIA.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – montre" loading="lazy" decoding="async" width="640" height="360" />
         </a>
       </div>

--- a/projets/index.html
+++ b/projets/index.html
@@ -53,31 +53,31 @@
     <section id="projects" class="project-gallery">
       <h2 class="visually-hidden">Galerie des projets</h2>
       <div class="grid">
-        <a class="project-card" href="/work/project1.html" data-title="Project 1 — Rendu 3D" data-category="3D">
+        <a class="project-card" href="/projets/project1.html" data-title="Project 1 — Rendu 3D" data-category="3D">
             <img class="project-img" src="/assets/images/PAGES_0_Couverture.jpg" srcset="/assets/images/PAGES_0_Couverture.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – couverture du magazine PAGES" loading="lazy" decoding="async" width="3508" height="2480" />
         </a>
-        <a class="project-card" href="/work/project2.html" data-title="Project 2 — Visuel conceptuel" data-category="2D">
+        <a class="project-card" href="/projets/project2.html" data-title="Project 2 — Visuel conceptuel" data-category="2D">
             <img class="project-img" src="/assets/images/project2.png" srcset="/assets/images/project2.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project3.html" data-title="Project 3 — Visuel conceptuel" data-category="VFX">
+        <a class="project-card" href="/projets/project3.html" data-title="Project 3 — Visuel conceptuel" data-category="VFX">
             <img class="project-img" src="/assets/images/project3.png" srcset="/assets/images/project3.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
         </a>
-        <a class="project-card" href="/work/project4.html" data-title="Project 4 — Visuel conceptuel" data-category="VR">
+        <a class="project-card" href="/projets/project4.html" data-title="Project 4 — Visuel conceptuel" data-category="VR">
             <img class="project-img" src="/assets/images/project4.png" srcset="/assets/images/project4.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project5.html" data-title="Project 5 — Visuel conceptuel" data-category="3D">
+        <a class="project-card" href="/projets/project5.html" data-title="Project 5 — Visuel conceptuel" data-category="3D">
             <img class="project-img" src="/assets/images/project5.png" srcset="/assets/images/project5.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
         </a>
-        <a class="project-card" href="/work/project6.html" data-title="Project 6 — Visuel conceptuel" data-category="2D">
+        <a class="project-card" href="/projets/project6.html" data-title="Project 6 — Visuel conceptuel" data-category="2D">
             <img class="project-img" src="/assets/images/project6.png" srcset="/assets/images/project6.png" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
         </a>
-        <a class="project-card" href="/work/project7.html" data-title="Project 7 — Rendu 3D" data-category="VFX">
+        <a class="project-card" href="/projets/project7.html" data-title="Project 7 — Rendu 3D" data-category="VFX">
             <img class="project-img" src="/assets/images/MENNECHET_Alex_Cognac_1.jpg" srcset="/assets/images/MENNECHET_Alex_Cognac_1.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – bouteille de cognac" loading="lazy" decoding="async" width="6254" height="3498" />
         </a>
-        <a class="project-card" href="/work/project8.html" data-title="Project 8 — Rendu 3D" data-category="3D">
+        <a class="project-card" href="/projets/project8.html" data-title="Project 8 — Rendu 3D" data-category="3D">
             <img class="project-img" src="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" srcset="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Rendu 3D – flacon de parfum" loading="lazy" decoding="async" width="3104" height="2160" />
         </a>
-        <a class="project-card" href="/work/project9.html" data-title="Project 9 — Visuel conceptuel" data-category="VR">
+        <a class="project-card" href="/projets/project9.html" data-title="Project 9 — Visuel conceptuel" data-category="VR">
             <img class="project-img" src="/assets/images/MontreMaisonEclatIA.jpg" srcset="/assets/images/MontreMaisonEclatIA.jpg" sizes="(max-width: 600px) 100vw, 33vw" alt="Visuel conceptuel – montre" loading="lazy" decoding="async" width="640" height="360" />
         </a>
       </div>

--- a/projets/project1.html
+++ b/projets/project1.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Modèle de projet du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project Template – Alex Chesnay" />
-  <meta property="og:description" content="Modèle de projet du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/placeholder2.png" />
+  <meta name="description" content="Project 1 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 1 – Alex Chesnay" />
+  <meta property="og:description" content="Project 1 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project1.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/" />
-  <title>Project Template</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project1.html" />
+  <title>Project 1</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project-template-schema.json"></script>
+  <script type="application/ld+json" src="/js/project1-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -44,48 +44,45 @@
 </header>
 
   <header class="project-hero">
-    <!-- Hero image or video -->
-    <img src="/assets/images/placeholder2.png" srcset="/assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" width="600" height="400" />
+    <div class="video-wrapper">
+      <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+    </div>
   </header>
-
+  <section class="gallery">
+    <div class="gallery-grid">
+      <img src="/assets/images/project1.png" alt="Vue 1 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project1.png" alt="Vue 2 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project1.png" alt="Vue 3 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
+    </div>
+  </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Titre du projet</h1>
-      <p>Pitch du projet.</p>
+      <h1>Project 1</h1>
+      <p>Pitch du premier projet.</p>
     </section>
-
     <section class="role">
       <h2>Rôle</h2>
-      <p>Description du rôle joué dans ce projet.</p>
+      <p>Mon rôle dans ce projet.</p>
     </section>
-
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil 1</li>
-        <li>Outil 2</li>
+        <li>Outil A</li>
+        <li>Outil B</li>
       </ul>
     </section>
-
     <section class="challenges">
       <h2>Défis &amp; Solutions</h2>
       <p>Défis rencontrés et solutions apportées.</p>
     </section>
-
-    <section class="gallery">
-      <h2>Galerie</h2>
-      <img src="/assets/images/placeholder3.png" srcset="/assets/images/placeholder3.png" sizes="100vw" alt="Exemple d’image de galerie pour le modèle" loading="lazy" decoding="async" width="600" height="400" />
-    </section>
-
     <section class="cta">
       <h2>Intéressé ?</h2>
       <a class="btn-primary" href="mailto:alex-mennechet@outlook.fr">Contactez-nous</a>
     </section>
   </main>
-
   <nav class="project-nav">
-    <a class="prev" href="/work/project3.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project1.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project6.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project2.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/project2.html
+++ b/projets/project2.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 4 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 4 – Alex Chesnay" />
-  <meta property="og:description" content="Project 4 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project4.png" />
+  <meta name="description" content="Project 2 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 2 – Alex Chesnay" />
+  <meta property="og:description" content="Project 2 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project2.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project4.html" />
-  <title>Project 4</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project2.html" />
+  <title>Project 2</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project4-schema.json"></script>
+  <script type="application/ld+json" src="/js/project2-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -50,15 +50,15 @@
   </header>
   <section class="gallery">
     <div class="gallery-grid">
-      <img src="/assets/images/project4.png" alt="Vue 1 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project4.png" alt="Vue 2 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project4.png" alt="Vue 3 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project2.png" alt="Vue 1 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project2.png" alt="Vue 2 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project2.png" alt="Vue 3 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
     </div>
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 4</h1>
-      <p>Pitch du quatrième projet.</p>
+      <h1>Project 2</h1>
+      <p>Pitch du deuxième projet.</p>
     </section>
     <section class="role">
       <h2>Rôle</h2>
@@ -67,8 +67,8 @@
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil A</li>
-        <li>Outil B</li>
+        <li>Outil C</li>
+        <li>Outil D</li>
       </ul>
     </section>
     <section class="challenges">
@@ -81,8 +81,8 @@
     </section>
   </main>
   <nav class="project-nav">
-    <a class="prev" href="/work/project3.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project5.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project1.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project3.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/project3.html
+++ b/projets/project3.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 5 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 5 – Alex Chesnay" />
-  <meta property="og:description" content="Project 5 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project5.png" />
+  <meta name="description" content="Project 3 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 3 – Alex Chesnay" />
+  <meta property="og:description" content="Project 3 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project3.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project5.html" />
-  <title>Project 5</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project3.html" />
+  <title>Project 3</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project5-schema.json"></script>
+  <script type="application/ld+json" src="/js/project3-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -50,15 +50,15 @@
   </header>
   <section class="gallery">
     <div class="gallery-grid">
-      <img src="/assets/images/project5.png" alt="Vue 1 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project5.png" alt="Vue 2 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project5.png" alt="Vue 3 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project3.png" alt="Vue 1 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
+      <img src="/assets/images/project3.png" alt="Vue 2 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
+      <img src="/assets/images/project3.png" alt="Vue 3 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
     </div>
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 5</h1>
-      <p>Pitch du cinquième projet.</p>
+      <h1>Project 3</h1>
+      <p>Pitch du troisième projet.</p>
     </section>
     <section class="role">
       <h2>Rôle</h2>
@@ -67,8 +67,8 @@
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil A</li>
-        <li>Outil B</li>
+        <li>Outil E</li>
+        <li>Outil F</li>
       </ul>
     </section>
     <section class="challenges">
@@ -81,8 +81,8 @@
     </section>
   </main>
   <nav class="project-nav">
-    <a class="prev" href="/work/project4.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project6.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project2.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project4.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/project4.html
+++ b/projets/project4.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 3 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 3 – Alex Chesnay" />
-  <meta property="og:description" content="Project 3 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project3.png" />
+  <meta name="description" content="Project 4 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 4 – Alex Chesnay" />
+  <meta property="og:description" content="Project 4 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project4.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project3.html" />
-  <title>Project 3</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project4.html" />
+  <title>Project 4</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project3-schema.json"></script>
+  <script type="application/ld+json" src="/js/project4-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -50,15 +50,15 @@
   </header>
   <section class="gallery">
     <div class="gallery-grid">
-      <img src="/assets/images/project3.png" alt="Vue 1 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
-      <img src="/assets/images/project3.png" alt="Vue 2 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
-      <img src="/assets/images/project3.png" alt="Vue 3 du projet 3" loading="lazy" decoding="async" width="1024" height="1536" />
+      <img src="/assets/images/project4.png" alt="Vue 1 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project4.png" alt="Vue 2 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project4.png" alt="Vue 3 du projet 4" loading="lazy" decoding="async" width="1536" height="1024" />
     </div>
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 3</h1>
-      <p>Pitch du troisième projet.</p>
+      <h1>Project 4</h1>
+      <p>Pitch du quatrième projet.</p>
     </section>
     <section class="role">
       <h2>Rôle</h2>
@@ -67,8 +67,8 @@
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil E</li>
-        <li>Outil F</li>
+        <li>Outil A</li>
+        <li>Outil B</li>
       </ul>
     </section>
     <section class="challenges">
@@ -81,8 +81,8 @@
     </section>
   </main>
   <nav class="project-nav">
-    <a class="prev" href="/work/project2.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project4.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project3.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project5.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/project5.html
+++ b/projets/project5.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 1 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 1 – Alex Chesnay" />
-  <meta property="og:description" content="Project 1 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project1.png" />
+  <meta name="description" content="Project 5 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 5 – Alex Chesnay" />
+  <meta property="og:description" content="Project 5 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project5.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project1.html" />
-  <title>Project 1</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project5.html" />
+  <title>Project 5</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project1-schema.json"></script>
+  <script type="application/ld+json" src="/js/project5-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -50,15 +50,15 @@
   </header>
   <section class="gallery">
     <div class="gallery-grid">
-      <img src="/assets/images/project1.png" alt="Vue 1 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project1.png" alt="Vue 2 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project1.png" alt="Vue 3 du projet 1" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project5.png" alt="Vue 1 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project5.png" alt="Vue 2 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project5.png" alt="Vue 3 du projet 5" loading="lazy" decoding="async" width="1536" height="1024" />
     </div>
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 1</h1>
-      <p>Pitch du premier projet.</p>
+      <h1>Project 5</h1>
+      <p>Pitch du cinquième projet.</p>
     </section>
     <section class="role">
       <h2>Rôle</h2>
@@ -81,8 +81,8 @@
     </section>
   </main>
   <nav class="project-nav">
-    <a class="prev" href="/work/project6.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project2.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project4.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project6.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/project6.html
+++ b/projets/project6.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 2 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 2 – Alex Chesnay" />
-  <meta property="og:description" content="Project 2 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project2.png" />
+  <meta name="description" content="Project 6 du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project 6 – Alex Chesnay" />
+  <meta property="og:description" content="Project 6 du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/project6.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project2.html" />
-  <title>Project 2</title>
+  <link rel="canonical" href="https://alexchesnay.com/projets/project6.html" />
+  <title>Project 6</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project2-schema.json"></script>
+  <script type="application/ld+json" src="/js/project6-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -50,15 +50,15 @@
   </header>
   <section class="gallery">
     <div class="gallery-grid">
-      <img src="/assets/images/project2.png" alt="Vue 1 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project2.png" alt="Vue 2 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
-      <img src="/assets/images/project2.png" alt="Vue 3 du projet 2" loading="lazy" decoding="async" width="1536" height="1024" />
+      <img src="/assets/images/project6.png" alt="Vue 1 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
+      <img src="/assets/images/project6.png" alt="Vue 2 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
+      <img src="/assets/images/project6.png" alt="Vue 3 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
     </div>
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 2</h1>
-      <p>Pitch du deuxième projet.</p>
+      <h1>Project 6</h1>
+      <p>Pitch du sixième projet.</p>
     </section>
     <section class="role">
       <h2>Rôle</h2>
@@ -67,8 +67,8 @@
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil C</li>
-        <li>Outil D</li>
+        <li>Outil A</li>
+        <li>Outil B</li>
       </ul>
     </section>
     <section class="challenges">
@@ -81,8 +81,8 @@
     </section>
   </main>
   <nav class="project-nav">
-    <a class="prev" href="/work/project1.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project3.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project5.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project1.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">

--- a/projets/template.html
+++ b/projets/template.html
@@ -4,14 +4,14 @@
   <script src="/js/init.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Project 6 du portfolio d'Alex Chesnay." />
-  <meta property="og:title" content="Project 6 – Alex Chesnay" />
-  <meta property="og:description" content="Project 6 du portfolio d'Alex Chesnay." />
-  <meta property="og:image" content="https://alexchesnay.com/assets/images/project6.png" />
+  <meta name="description" content="Modèle de projet du portfolio d'Alex Chesnay." />
+  <meta property="og:title" content="Project Template – Alex Chesnay" />
+  <meta property="og:description" content="Modèle de projet du portfolio d'Alex Chesnay." />
+  <meta property="og:image" content="https://alexchesnay.com/assets/images/placeholder2.png" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="canonical" href="https://alexchesnay.com/work/project6.html" />
-  <title>Project 6</title>
+  <link rel="canonical" href="https://alexchesnay.com/" />
+  <title>Project Template</title>
     <link rel="stylesheet" href="/css/style.min.css?v=nav-fix-02">
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/fontawesome.min.css"
@@ -21,7 +21,7 @@
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/brands.min.css"
           crossorigin="anonymous"
           referrerpolicy="no-referrer">
-  <script type="application/ld+json" src="/js/project6-schema.json"></script>
+  <script type="application/ld+json" src="/js/project-template-schema.json"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu principal</a>
@@ -44,45 +44,48 @@
 </header>
 
   <header class="project-hero">
-    <div class="video-wrapper">
-      <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-    </div>
+    <!-- Hero image or video -->
+    <img src="/assets/images/placeholder2.png" srcset="/assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" width="600" height="400" />
   </header>
-  <section class="gallery">
-    <div class="gallery-grid">
-      <img src="/assets/images/project6.png" alt="Vue 1 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
-      <img src="/assets/images/project6.png" alt="Vue 2 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
-      <img src="/assets/images/project6.png" alt="Vue 3 du projet 6" loading="lazy" decoding="async" width="1024" height="1536" />
-    </div>
-  </section>
+
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 6</h1>
-      <p>Pitch du sixième projet.</p>
+      <h1>Titre du projet</h1>
+      <p>Pitch du projet.</p>
     </section>
+
     <section class="role">
       <h2>Rôle</h2>
-      <p>Mon rôle dans ce projet.</p>
+      <p>Description du rôle joué dans ce projet.</p>
     </section>
+
     <section class="tools">
       <h2>Outils</h2>
       <ul>
-        <li>Outil A</li>
-        <li>Outil B</li>
+        <li>Outil 1</li>
+        <li>Outil 2</li>
       </ul>
     </section>
+
     <section class="challenges">
       <h2>Défis &amp; Solutions</h2>
       <p>Défis rencontrés et solutions apportées.</p>
     </section>
+
+    <section class="gallery">
+      <h2>Galerie</h2>
+      <img src="/assets/images/placeholder3.png" srcset="/assets/images/placeholder3.png" sizes="100vw" alt="Exemple d’image de galerie pour le modèle" loading="lazy" decoding="async" width="600" height="400" />
+    </section>
+
     <section class="cta">
       <h2>Intéressé ?</h2>
       <a class="btn-primary" href="mailto:alex-mennechet@outlook.fr">Contactez-nous</a>
     </section>
   </main>
+
   <nav class="project-nav">
-    <a class="prev" href="/work/project5.html" aria-label="Projet précédent">Projet précédent</a>
-    <a class="next" href="/work/project1.html" aria-label="Projet suivant">Projet suivant</a>
+    <a class="prev" href="/projets/project3.html" aria-label="Projet précédent">Projet précédent</a>
+    <a class="next" href="/projets/project1.html" aria-label="Projet suivant">Projet suivant</a>
   </nav>
   <footer class="site-footer">
   <div class="footer-content">


### PR DESCRIPTION
## Summary
- relocate project detail HTML files to `projets/` and update canonical/prev-next links
- point project listings to `/projets/{slug}.html`
- add redirect for legacy `/work/*` paths

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689cf05d31808324beae12bd0b15f9c7