### PR TITLE
Refactor project headers to include breadcrumb and hero

### DIFF
--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -51,14 +51,15 @@ export default function Project({ project, prev, next }) {
         />
       </Head>
       <main>
-        <Breadcrumb
-          items={[
-            { label: 'Accueil', href: '/' },
-            { label: 'Projets', href: '/projets/' },
-            { label: project.title }
-          ]}
-        />
         <header className="project-hero">
+          <Breadcrumb
+            items={[
+              { label: 'Accueil', href: '/' },
+              { label: 'Projets', href: '/projets/' },
+              { label: project.title }
+            ]}
+          />
+          <h1>{project.title}</h1>
           <img
             className="hero-media"
             src={project.images[0]}
@@ -74,7 +75,6 @@ export default function Project({ project, prev, next }) {
         </header>
         <div className="project-content" style={{ padding: theme.spacing.lg }}>
           <section className="pitch">
-            <h1>{project.title}</h1>
             <p>{project.description}</p>
           </section>
 

--- a/projets/project1.html
+++ b/projets/project1.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 1</span></li>
+      </ol>
+    </nav>
+    <h1>Project 1</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 1</h1>
       <p>Pitch du premier projet.</p>
     </section>
     <section class="role">

--- a/projets/project2.html
+++ b/projets/project2.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 2</span></li>
+      </ol>
+    </nav>
+    <h1>Project 2</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 2</h1>
       <p>Pitch du deuxième projet.</p>
     </section>
     <section class="role">

--- a/projets/project3.html
+++ b/projets/project3.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 3</span></li>
+      </ol>
+    </nav>
+    <h1>Project 3</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 3</h1>
       <p>Pitch du troisième projet.</p>
     </section>
     <section class="role">

--- a/projets/project4.html
+++ b/projets/project4.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 4</span></li>
+      </ol>
+    </nav>
+    <h1>Project 4</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 4</h1>
       <p>Pitch du quatrième projet.</p>
     </section>
     <section class="role">

--- a/projets/project5.html
+++ b/projets/project5.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 5</span></li>
+      </ol>
+    </nav>
+    <h1>Project 5</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 5</h1>
       <p>Pitch du cinquième projet.</p>
     </section>
     <section class="role">

--- a/projets/project6.html
+++ b/projets/project6.html
@@ -44,6 +44,14 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Project 6</span></li>
+      </ol>
+    </nav>
+    <h1>Project 6</h1>
     <div class="video-wrapper">
       <iframe class="hero-media" src="https://player.vimeo.com/video/76979871" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -57,7 +65,6 @@
   </section>
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Project 6</h1>
       <p>Pitch du sixième projet.</p>
     </section>
     <section class="role">

--- a/projets/template.html
+++ b/projets/template.html
@@ -44,13 +44,20 @@
 </header>
 
   <header class="project-hero">
+    <nav aria-label="Fil d'Ariane">
+      <ol class="breadcrumb">
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/projets/">Projets</a></li>
+        <li><span aria-current="page">Titre du projet</span></li>
+      </ol>
+    </nav>
+    <h1>Titre du projet</h1>
     <!-- Hero image or video -->
     <img src="/assets/images/placeholder2.png" srcset="/assets/images/placeholder2.png" sizes="100vw" alt="Image de couverture du modèle de projet" class="hero-media" decoding="async" width="600" height="400" />
   </header>
 
   <main id="main" class="project-content">
     <section class="pitch">
-      <h1>Titre du projet</h1>
       <p>Pitch du projet.</p>
     </section>
 


### PR DESCRIPTION
## Summary
- Consolidate project breadcrumbs and titles into a unified header with hero media
- Mirror header structure in static project templates for consistent breadcrumb > title > hero order

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689d02860f6c832480685e39b46cd270