### PR TITLE
Add SimilarItems section for related projects

### DIFF
--- a/components/SimilarItems.js
+++ b/components/SimilarItems.js
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import theme from '../styles/theme';
+
+export default function SimilarItems({ items, imageSizes }) {
+  if (!items || items.length === 0) return null;
+  return (
+    <section className="similar-items" style={{ margin: `${theme.spacing.lg} 0` }}>
+      <h2>Projets similaires</h2>
+      <div className="grid">
+        {items.map((p) => {
+          const size = imageSizes[p.images[0]] || { width: 800, height: 600 };
+          return (
+            <Link
+              key={p.slug}
+              href={`/projets/${p.slug}.html`}
+              className="project-card"
+            >
+              <img
+                src={p.images[0]}
+                alt={p.imageAlts ? p.imageAlts[0] : p.title}
+                className="project-img"
+                loading="lazy"
+                decoding="async"
+                width={size.width}
+                height={size.height}
+              />
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import theme from '../../styles/theme';
 import Breadcrumb from '../../components/Breadcrumb';
 import Gallery from '../../components/Gallery';
+import SimilarItems from '../../components/SimilarItems';
 
 const siteUrl = 'https://alex-chesnay.com';
 const imageSizes = {
@@ -14,7 +15,7 @@ const imageSizes = {
   '/assets/images/project4.png': { width: 1536, height: 1024 }
 };
 
-export default function Project({ project, prev, next }) {
+export default function Project({ project, prev, next, related }) {
   const url = `${siteUrl}/projets/${project.slug}.html`;
   const image = `${siteUrl}${project.images[0]}`;
   const title = `${project.title} - Projet - Alex Chesnay`;
@@ -155,6 +156,8 @@ export default function Project({ project, prev, next }) {
             </a>
           </section>
 
+          <SimilarItems items={related} imageSizes={imageSizes} />
+
           <Link className="back-link" href="/projets/">
             Retour à la galerie
           </Link>
@@ -203,5 +206,8 @@ export async function getStaticProps({ params }) {
   const project = projects[index];
   const prev = projects[index - 1] || null;
   const next = projects[index + 1] || null;
-  return { props: { project, prev, next } };
+  const related = projects.filter(
+    (p) => p.category === project.category && p.slug !== project.slug
+  );
+  return { props: { project, prev, next, related } };
 }

--- a/projets/template.html
+++ b/projets/template.html
@@ -105,6 +105,20 @@
       <h2>Intéressé ?</h2>
       <a class="btn-primary" href="mailto:alex-mennechet@outlook.fr">Contactez-nous</a>
     </section>
+
+    <section class="similar-items">
+      <h2>Projets similaires</h2>
+      <div class="grid">
+        <a class="project-card" href="/projets/project1.html">
+          <img src="/assets/images/placeholder2.png" alt="Projet similaire"
+               class="project-img" loading="lazy" decoding="async" width="600" height="400" />
+        </a>
+        <a class="project-card" href="/projets/project2.html">
+          <img src="/assets/images/placeholder2.png" alt="Projet similaire"
+               class="project-img" loading="lazy" decoding="async" width="600" height="400" />
+        </a>
+      </div>
+    </section>
   </main>
 
   <nav class="project-nav">


### PR DESCRIPTION
## Summary
- show related projects using new SimilarItems component on project pages
- fetch related projects from `projects.json`
- include placeholder similar items section in project template

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689d097954308324873439386a7f1094