### PR TITLE
Add product grid to store landing page

### DIFF
--- a/pages/store/facial-modeling-timelapse.js
+++ b/pages/store/facial-modeling-timelapse.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../components/Breadcrumb';
+import Card from '../../components/Card';
+
+export default function FacialModelingTimelapse() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Boutique', href: '/store' },
+          { label: 'Facial Modeling Timelapse' }
+        ]}
+      />
+      <h1>Facial Modeling Timelapse</h1>
+      <Card>
+        <img src="/assets/images/placeholder3.png" alt="Facial Modeling Timelapse" width="640" height="360" />
+        <p>Timelapse de la création d’un modèle facial.</p>
+      </Card>
+    </main>
+  );
+}

--- a/pages/store/index.js
+++ b/pages/store/index.js
@@ -1,6 +1,23 @@
 import Breadcrumb from '../../components/Breadcrumb';
+import Card from '../../components/Card';
+import Link from 'next/link';
 
 export default function StoreIndex() {
+  const products = [
+    {
+      slug: 'roller-derby-girl',
+      title: 'RollerDerbyGirl',
+      description: 'Modèle 3D dynamique d’une athlète de roller derby.',
+      image: '/assets/images/placeholder2.png'
+    },
+    {
+      slug: 'facial-modeling-timelapse',
+      title: 'Facial Modeling Timelapse',
+      description: 'Timelapse de la création d’un modèle facial.',
+      image: '/assets/images/placeholder3.png'
+    }
+  ];
+
   return (
     <main style={{ padding: 'var(--space-lg)' }}>
       <Breadcrumb
@@ -10,7 +27,16 @@ export default function StoreIndex() {
         ]}
       />
       <h1>Boutique</h1>
-      <p>Contenu de la boutique à venir.</p>
+      <section className="card-grid">
+        {products.map((product) => (
+          <Card key={product.slug}>
+            <img src={product.image} alt={product.title} width="640" height="360" />
+            <h2>{product.title}</h2>
+            <p>{product.description}</p>
+            <Link href={`/store/${product.slug}`}>Voir le produit</Link>
+          </Card>
+        ))}
+      </section>
     </main>
   );
 }

--- a/pages/store/roller-derby-girl.js
+++ b/pages/store/roller-derby-girl.js
@@ -1,0 +1,21 @@
+import Breadcrumb from '../../components/Breadcrumb';
+import Card from '../../components/Card';
+
+export default function RollerDerbyGirl() {
+  return (
+    <main style={{ padding: 'var(--space-lg)' }}>
+      <Breadcrumb
+        items={[
+          { label: 'Accueil', href: '/' },
+          { label: 'Boutique', href: '/store' },
+          { label: 'RollerDerbyGirl' }
+        ]}
+      />
+      <h1>RollerDerbyGirl</h1>
+      <Card>
+        <img src="/assets/images/placeholder2.png" alt="RollerDerbyGirl" width="640" height="360" />
+        <p>Modèle 3D dynamique d’une athlète de roller derby.</p>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace store placeholder with responsive grid using Card components
- add basic product pages for RollerDerbyGirl and Facial Modeling Timelapse

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d158624448324916d730da3736970