### PR TITLE
feat: add blog category cards

### DIFF
--- a/components/CategoryCard.js
+++ b/components/CategoryCard.js
@@ -1,0 +1,10 @@
+import Link from 'next/link';
+import styles from './CategoryCard.module.css';
+
+export default function CategoryCard({ name, slug }) {
+  return (
+    <Link href={`/blog/${slug}`} className={styles.card}>
+      {name}
+    </Link>
+  );
+}

--- a/components/CategoryCard.module.css
+++ b/components/CategoryCard.module.css
@@ -1,0 +1,21 @@
+.card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: var(--color-white);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 500;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover,
+.card:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,12 +1,20 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
-import { useState } from 'react';
 import theme from '../../styles/theme';
-import BlogCard from '../../components/BlogCard';
-import posts from '../../private/blog.json' assert { type: 'json' };
 import Breadcrumb from '../../components/Breadcrumb';
+import CategoryCard from '../../components/CategoryCard';
 
 const siteUrl = 'https://alex-chesnay.com';
+
+const categories = [
+  { name: 'Interviews', slug: 'interviews' },
+  { name: 'Lectures', slug: 'lectures' },
+  { name: 'Modeling', slug: 'modeling' },
+  { name: 'News', slug: 'news' },
+  { name: 'Projects', slug: 'projects' },
+  { name: 'Resources', slug: 'resources' },
+  { name: 'Rigging', slug: 'rigging' }
+];
 
 export default function Blog() {
   const title = "Blog - Studio d'animation 3D Alex Chesnay";
@@ -14,9 +22,6 @@ export default function Blog() {
     "Actualités du studio d'animation 3D et articles récents.";
   const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
   const url = `${siteUrl}/blog`;
-  const [visibleCount, setVisibleCount] = useState(1);
-
-  const loadMore = () => setVisibleCount((c) => c + 1);
 
   return (
     <>
@@ -49,17 +54,10 @@ export default function Blog() {
         />
         <h1>Blog du studio d'animation 3D</h1>
         <div className="responsive-grid">
-          {posts.slice(0, visibleCount).map((post) => (
-            <BlogCard key={post.slug} {...post} />
+          {categories.map((category) => (
+            <CategoryCard key={category.slug} {...category} />
           ))}
         </div>
-        {visibleCount < posts.length && (
-          <div style={{ textAlign: 'center', marginTop: theme.spacing.lg }}>
-            <button onClick={loadMore} className="contact-button">
-              Charger plus
-            </button>
-          </div>
-        )}
       </motion.main>
     </>
   );


### PR DESCRIPTION
## Summary
- replace blog post list with grid of blog categories
- add reusable CategoryCard component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1cf651d4832495facb4f1e9f8441