### PR TITLE
feat(blog): add category pages

### DIFF
--- a/pages/blog/[category]/index.js
+++ b/pages/blog/[category]/index.js
@@ -1,0 +1,72 @@
+import Head from 'next/head';
+import { motion } from 'framer-motion';
+import fs from 'fs';
+import path from 'path';
+import theme from '../../../styles/theme';
+import Breadcrumb from '../../../components/Breadcrumb';
+import BlogCard from '../../../components/BlogCard';
+
+const siteUrl = 'https://alex-chesnay.com';
+
+export default function BlogCategoryPage({ category, posts }) {
+  const title = `${category} - Blog - Studio d'animation 3D Alex Chesnay`;
+  const description = `Articles de la catégorie ${category}.`;
+  const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
+  const url = `${siteUrl}/blog/${category}`;
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content={image} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
+        <link rel="canonical" href={url} />
+      </Head>
+      <motion.main
+        style={{ padding: theme.spacing.lg }}
+        initial={{ opacity: 0, y: 40 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
+        <Breadcrumb
+          items={[
+            { label: 'Accueil', href: '/' },
+            { label: 'Blog', href: '/blog' },
+            { label: category }
+          ]}
+        />
+        <h1>{category}</h1>
+        <div className="responsive-grid">
+          {posts.map((post) => (
+            <BlogCard key={post.slug} {...post} />
+          ))}
+        </div>
+      </motion.main>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  const filePath = path.join(process.cwd(), 'private', 'blog.json');
+  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const categories = Array.from(new Set(posts.map((p) => p.category)));
+  const paths = categories.map((category) => ({ params: { category } }));
+  return { paths, fallback: false };
+}
+
+export async function getStaticProps({ params }) {
+  const filePath = path.join(process.cwd(), 'private', 'blog.json');
+  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const filtered = posts.filter((p) => p.category === params.category);
+  return { props: { category: params.category, posts: filtered } };
+}
+

--- a/private/blog.json
+++ b/private/blog.json
@@ -5,6 +5,7 @@
     "description": "Introduction au blog et premières actualités.",
     "excerpt": "Introduction au blog et premières actualités.",
     "date": "1 janvier 2023",
+    "category": "news",
     "image": "/assets/images/PAGES_0_Couverture.jpg",
     "content": "<p>Bienvenue sur notre blog&nbsp;! Nous partagerons ici nos projets, conseils et retours d'expérience dans le domaine de la 3D.</p>"
   },
@@ -14,6 +15,7 @@
     "description": "Actualités récentes de notre studio d'animation 3D et projets en cours.",
     "excerpt": "Les dernières nouveautés du studio d'animation 3D.",
     "date": "15 février 2023",
+    "category": "projects",
     "image": "/assets/images/ProjetGateauxRendu1.jpg",
     "content": "<p>Notre studio d'animation 3D continue d'innover avec de nouveaux projets et collaborations. Découvrez un aperçu de nos dernières réalisations ci-dessous.</p><img src='/assets/images/ProjetGateauxRendu1.jpg' alt='Exemple de rendu d\'animation 3D d\'un gâteau coloré' style='max-width:100%;height:auto' loading='lazy' decoding='async' width='1841' height='1035' />"
   }


### PR DESCRIPTION
## Summary
- add dynamic blog category page rendering posts by category
- populate blog entries with category metadata

## Testing
- `npm test`
- `npm run lint` *(fails: requires manual ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e3371988324aac242c1fed7bdb4