### PR TITLE
feat: add category support to blog

### DIFF
--- a/components/BlogCard.js
+++ b/components/BlogCard.js
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import styles from './BlogCard.module.css';
 
-export default function BlogCard({ title, date, excerpt, slug, image = '/assets/images/placeholder2.png' }) {
+export default function BlogCard({
+  title,
+  date,
+  excerpt,
+  slug,
+  image = '/assets/images/placeholder2.png',
+  category
+}) {
   return (
     <article className={styles.card}>
       <div className={styles.imageWrapper}>
@@ -16,6 +23,9 @@ export default function BlogCard({ title, date, excerpt, slug, image = '/assets/
         />
       </div>
       <div className={styles.content}>
+        <Link href={`/blog/${category}`} className={styles.category}>
+          {category}
+        </Link>
         <h2 className={styles.title}>{title}</h2>
         <time className={styles.date}>{date}</time>
         <p className={styles.excerpt}>{excerpt}</p>

--- a/components/BlogCard.module.css
+++ b/components/BlogCard.module.css
@@ -42,6 +42,14 @@
   flex-direction: column;
 }
 
+.category {
+  font-size: 0.875rem;
+  color: #666;
+  text-transform: capitalize;
+  margin-bottom: var(--space-sm);
+  display: inline-block;
+}
+
 .title {
   margin: 0 0 var(--space-sm);
   font-size: 1.25rem;

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Load and validate blog posts from the JSON file.
+ * Ensures each post contains the required keys.
+ * @returns {Array<Object>} list of posts
+ */
+export function getAllPosts() {
+  const filePath = path.join(process.cwd(), 'private', 'blog.json');
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const posts = JSON.parse(raw);
+  validatePosts(posts);
+  return posts;
+}
+
+const requiredKeys = [
+  'slug',
+  'title',
+  'description',
+  'excerpt',
+  'date',
+  'category',
+  'image',
+  'content'
+];
+
+function validatePosts(posts) {
+  if (!Array.isArray(posts)) {
+    throw new Error('Blog data must be an array of posts');
+  }
+  posts.forEach((post, index) => {
+    requiredKeys.forEach((key) => {
+      if (typeof post[key] !== 'string' || post[key].length === 0) {
+        throw new Error(`Post at index ${index} is missing required field: ${key}`);
+      }
+    });
+  });
+}
+
+export function getPostBySlug(slug) {
+  const posts = getAllPosts();
+  return posts.find((p) => p.slug === slug);
+}
+
+export function getPostsByCategory(category) {
+  const posts = getAllPosts();
+  return posts.filter((p) => p.category === category);
+}
+
+export function getCategories() {
+  const posts = getAllPosts();
+  return Array.from(new Set(posts.map((p) => p.category)));
+}

--- a/pages/blog/[category]/index.js
+++ b/pages/blog/[category]/index.js
@@ -1,10 +1,9 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
-import fs from 'fs';
-import path from 'path';
 import theme from '../../../styles/theme';
 import Breadcrumb from '../../../components/Breadcrumb';
 import BlogCard from '../../../components/BlogCard';
+import { getPostsByCategory, getCategories } from '../../../lib/blog';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -56,17 +55,13 @@ export default function BlogCategoryPage({ category, posts }) {
 }
 
 export async function getStaticPaths() {
-  const filePath = path.join(process.cwd(), 'private', 'blog.json');
-  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const categories = Array.from(new Set(posts.map((p) => p.category)));
+  const categories = getCategories();
   const paths = categories.map((category) => ({ params: { category } }));
   return { paths, fallback: false };
 }
 
 export async function getStaticProps({ params }) {
-  const filePath = path.join(process.cwd(), 'private', 'blog.json');
-  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const filtered = posts.filter((p) => p.category === params.category);
+  const filtered = getPostsByCategory(params.category);
   return { props: { category: params.category, posts: filtered } };
 }
 

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,9 +1,8 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
-import fs from 'fs';
-import path from 'path';
 import theme from '../../styles/theme';
 import Breadcrumb from '../../components/Breadcrumb';
+import { getAllPosts, getPostBySlug } from '../../lib/blog';
 
 const siteUrl = 'https://alex-chesnay.com';
 
@@ -40,6 +39,7 @@ export default function BlogPost({ post }) {
           items={[
             { label: 'Accueil', href: '/' },
             { label: 'Blog', href: '/blog/' },
+            { label: post.category, href: `/blog/${post.category}` },
             { label: post.title }
           ]}
         />
@@ -51,15 +51,12 @@ export default function BlogPost({ post }) {
 }
 
 export async function getStaticPaths() {
-  const filePath = path.join(process.cwd(), 'private', 'blog.json');
-  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const posts = getAllPosts();
   const paths = posts.map((p) => ({ params: { slug: p.slug } }));
   return { paths, fallback: false };
 }
 
 export async function getStaticProps({ params }) {
-  const filePath = path.join(process.cwd(), 'private', 'blog.json');
-  const posts = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const post = posts.find((p) => p.slug === params.slug);
+  const post = getPostBySlug(params.slug);
   return { props: { post } };
 }


### PR DESCRIPTION
## Summary
- add schema validation helpers for blog posts
- expose post category in BlogCard and blog post page
- use validated helpers for category listings and slugs

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689d2124f57c8324bde91ac7fbb4ba68