### PR TITLE
feat: add blog post meta and content styling

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import theme from '../../styles/theme';
 import Breadcrumb from '../../components/Breadcrumb';
 import { getAllPosts, getPostBySlug } from '../../lib/blog';
@@ -44,7 +45,15 @@ export default function BlogPost({ post }) {
           ]}
         />
         <h1>{post.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: post.content }} />
+        <div className="post-meta">
+          <time dateTime={post.date}>{post.date}</time>
+          {' • '}
+          <Link href={`/blog/${post.category}`}>{post.category}</Link>
+        </div>
+        <article
+          className="post-content"
+          dangerouslySetInnerHTML={{ __html: post.content }}
+        />
       </motion.main>
     </>
   );

--- a/private/blog.json
+++ b/private/blog.json
@@ -17,6 +17,6 @@
     "date": "15 février 2023",
     "category": "projects",
     "image": "/assets/images/ProjetGateauxRendu1.jpg",
-    "content": "<p>Notre studio d'animation 3D continue d'innover avec de nouveaux projets et collaborations. Découvrez un aperçu de nos dernières réalisations ci-dessous.</p><img src='/assets/images/ProjetGateauxRendu1.jpg' alt='Exemple de rendu d\'animation 3D d\'un gâteau coloré' style='max-width:100%;height:auto' loading='lazy' decoding='async' width='1841' height='1035' />"
+    "content": "<p>Notre studio d'animation 3D continue d'innover avec de nouveaux projets et collaborations. Découvrez un aperçu de nos dernières réalisations ci-dessous.</p><figure><img src='/assets/images/ProjetGateauxRendu1.jpg' alt='Exemple de rendu d\'animation 3D d\'un gâteau coloré' style='max-width:100%;height:auto' loading='lazy' decoding='async' width='1841' height='1035' /><figcaption>Exemple de rendu d'animation 3D d'un gâteau coloré</figcaption></figure>"
   }
 ]

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -117,6 +117,48 @@ p {
   line-height: var(--lh-relaxed);
 }
 
+.post-meta {
+  margin-bottom: var(--space-lg);
+  font-size: 0.875rem;
+  color: var(--color-text);
+  opacity: 0.7;
+}
+
+.post-content h2 {
+  margin-top: var(--space-xl);
+}
+
+.post-content ul,
+.post-content ol {
+  padding-left: var(--space-lg);
+  margin-bottom: var(--space-md);
+}
+
+.post-content blockquote {
+  margin: var(--space-lg) 0;
+  padding-left: var(--space-lg);
+  border-left: 4px solid var(--color-primary);
+  font-style: italic;
+}
+
+.post-content img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.post-content figure {
+  margin: var(--space-lg) 0;
+}
+
+.post-content figcaption {
+  margin-top: var(--space-sm);
+  font-size: 0.875rem;
+  text-align: center;
+  color: var(--color-text);
+  opacity: 0.8;
+}
+
 .hero-tagline {
   font-family: 'Raleway', sans-serif;
   font-size: clamp(1rem, 2vw + 0.5rem, 1.25rem);


### PR DESCRIPTION
## Summary
- add publication meta block for blog posts
- style headings, lists, and figures in article content
- support image captions with figure/figcaption markup

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689d22d95d988324a6994528e5516e3d