### PR TITLE
feat: blog pagination, navigation, and related posts

### DIFF
--- a/pages/blog/[category]/index.js
+++ b/pages/blog/[category]/index.js
@@ -3,15 +3,24 @@ import { motion } from 'framer-motion';
 import theme from '../../../styles/theme';
 import Breadcrumb from '../../../components/Breadcrumb';
 import BlogCard from '../../../components/BlogCard';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { getPostsByCategory, getCategories } from '../../../lib/blog';
 
 const siteUrl = 'https://alex-chesnay.com';
 
+const POSTS_PER_PAGE = 6;
+
 export default function BlogCategoryPage({ category, posts }) {
+  const router = useRouter();
+  const page = parseInt(router.query.page || '1', 10);
   const title = `${category} - Blog - Studio d'animation 3D Alex Chesnay`;
   const description = `Articles de la catégorie ${category}.`;
   const image = `${siteUrl}/assets/images/PAGES_0_Couverture.jpg`;
   const url = `${siteUrl}/blog/${category}`;
+  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
+  const startIndex = (page - 1) * POSTS_PER_PAGE;
+  const paginatedPosts = posts.slice(startIndex, startIndex + POSTS_PER_PAGE);
 
   return (
     <>
@@ -45,10 +54,18 @@ export default function BlogCategoryPage({ category, posts }) {
         />
         <h1>{category}</h1>
         <div className="responsive-grid">
-          {posts.map((post) => (
+          {paginatedPosts.map((post) => (
             <BlogCard key={post.slug} {...post} />
           ))}
         </div>
+        <nav className="pagination">
+          {page > 1 && (
+            <Link href={`/blog/${category}?page=${page - 1}`}>Précédent</Link>
+          )}
+          {page < totalPages && (
+            <Link href={`/blog/${category}?page=${page + 1}`}>Suivant</Link>
+          )}
+        </nav>
       </motion.main>
     </>
   );

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -3,11 +3,12 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import theme from '../../styles/theme';
 import Breadcrumb from '../../components/Breadcrumb';
+import BlogCard from '../../components/BlogCard';
 import { getAllPosts, getPostBySlug } from '../../lib/blog';
 
 const siteUrl = 'https://alex-chesnay.com';
 
-export default function BlogPost({ post }) {
+export default function BlogPost({ post, prevPost, nextPost, relatedPosts }) {
   const url = `${siteUrl}/blog/${post.slug}`;
   const image = `${siteUrl}${post.image}`;
   const title = `${post.title} - Alex Chesnay`;
@@ -54,6 +55,24 @@ export default function BlogPost({ post }) {
           className="post-content"
           dangerouslySetInnerHTML={{ __html: post.content }}
         />
+        <nav className="post-navigation">
+          {prevPost && (
+            <Link href={`/blog/${prevPost.slug}`}>{`← ${prevPost.title}`}</Link>
+          )}
+          {nextPost && (
+            <Link href={`/blog/${nextPost.slug}`}>{`${nextPost.title} →`}</Link>
+          )}
+        </nav>
+        {relatedPosts.length > 0 && (
+          <section className="related-posts">
+            <h2>Articles similaires</h2>
+            <div className="responsive-grid">
+              {relatedPosts.map((p) => (
+                <BlogCard key={p.slug} {...p} />
+              ))}
+            </div>
+          </section>
+        )}
       </motion.main>
     </>
   );
@@ -67,5 +86,17 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const post = getPostBySlug(params.slug);
-  return { props: { post } };
+  const posts = getAllPosts().sort(
+    (a, b) => new Date(a.date) - new Date(b.date)
+  );
+  const index = posts.findIndex((p) => p.slug === params.slug);
+  const prevPost = index > 0 ? posts[index - 1] : null;
+  const nextPost = index < posts.length - 1 ? posts[index + 1] : null;
+  const relatedPosts = posts
+    .filter(
+      (p) => p.category === post.category && p.slug !== post.slug
+    )
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
+    .slice(0, 3);
+  return { props: { post, prevPost, nextPost, relatedPosts } };
 }


### PR DESCRIPTION
## Summary
- paginate category pages with query param `?page=` and add prev/next controls
- add previous/next post navigation and related posts section on article pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d24a7b9f48324aadcedfb5e4637ee