### PR TITLE
Refine blog spacing and responsive columns

### DIFF
--- a/components/BlogCard.module.css
+++ b/components/BlogCard.module.css
@@ -35,34 +35,39 @@
   transform: scale(1.05);
 }
 
+
 .content {
   padding: var(--space-md);
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: var(--space-sm);
 }
 
 .category {
   font-size: 0.875rem;
   color: #666;
   text-transform: capitalize;
-  margin-bottom: var(--space-sm);
+  line-height: var(--lh-base);
   display: inline-block;
 }
 
 .title {
-  margin: 0 0 var(--space-sm);
+  margin: 0;
   font-size: 1.25rem;
+  line-height: var(--lh-tight);
 }
 
 .date {
   font-size: 0.875rem;
   color: #666;
+  line-height: var(--lh-base);
 }
 
 .excerpt {
-  margin: var(--space-sm) 0 var(--space-md);
+  margin: 0;
   flex: 1;
+  line-height: var(--lh-relaxed);
 }
 
 .readButton {

--- a/pages/blog/Category.module.css
+++ b/pages/blog/Category.module.css
@@ -1,0 +1,21 @@
+.container {
+  padding: var(--space-lg);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-lg);
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/pages/blog/Post.module.css
+++ b/pages/blog/Post.module.css
@@ -1,0 +1,18 @@
+.container {
+  padding: var(--space-lg);
+}
+
+.navigation {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin: var(--space-xl) 0;
+}
+
+.related {
+  margin-top: var(--space-xl);
+}
+
+.grid {
+  gap: var(--space-lg);
+}

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,9 +1,9 @@
 import Head from 'next/head';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import theme from '../../styles/theme';
 import Breadcrumb from '../../components/Breadcrumb';
 import BlogCard from '../../components/BlogCard';
+import styles from './Post.module.css';
 import { getAllPosts, getPostBySlug } from '../../lib/blog';
 
 const siteUrl = 'https://alex-chesnay.com';
@@ -31,7 +31,7 @@ export default function BlogPost({ post, prevPost, nextPost, relatedPosts }) {
         <link rel="canonical" href={url} />
       </Head>
       <motion.main
-        style={{ padding: theme.spacing.lg }}
+        className={styles.container}
         initial={{ opacity: 0, y: 40 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -55,7 +55,7 @@ export default function BlogPost({ post, prevPost, nextPost, relatedPosts }) {
           className="post-content"
           dangerouslySetInnerHTML={{ __html: post.content }}
         />
-        <nav className="post-navigation">
+        <nav className={styles.navigation}>
           {prevPost && (
             <Link href={`/blog/${prevPost.slug}`}>{`← ${prevPost.title}`}</Link>
           )}
@@ -64,9 +64,9 @@ export default function BlogPost({ post, prevPost, nextPost, relatedPosts }) {
           )}
         </nav>
         {relatedPosts.length > 0 && (
-          <section className="related-posts">
+          <section className={styles.related}>
             <h2>Articles similaires</h2>
-            <div className="responsive-grid">
+            <div className={`${styles.grid} responsive-grid`}>
               {relatedPosts.map((p) => (
                 <BlogCard key={p.slug} {...p} />
               ))}

--- a/pages/blog/news.js
+++ b/pages/blog/news.js
@@ -1,8 +1,11 @@
 import Breadcrumb from '../../components/Breadcrumb';
+import BlogCard from '../../components/BlogCard';
+import { getPostsByCategory } from '../../lib/blog';
+import styles from './Category.module.css';
 
-export default function BlogNews() {
+export default function BlogNews({ posts }) {
   return (
-    <main style={{ padding: 'var(--space-lg)' }}>
+    <main className={styles.container}>
       <Breadcrumb
         items={[
           { label: 'Accueil', href: '/' },
@@ -11,7 +14,20 @@ export default function BlogNews() {
         ]}
       />
       <h1>Actualités</h1>
-      <p>Les actualités seront publiées ici.</p>
+      {posts.length > 0 ? (
+        <div className={`${styles.grid} responsive-grid`}>
+          {posts.map((p) => (
+            <BlogCard key={p.slug} {...p} />
+          ))}
+        </div>
+      ) : (
+        <p>Les actualités seront publiées ici.</p>
+      )}
     </main>
   );
+}
+
+export async function getStaticProps() {
+  const posts = getPostsByCategory('news');
+  return { props: { posts } };
 }

--- a/pages/blog/tutorials.js
+++ b/pages/blog/tutorials.js
@@ -1,8 +1,11 @@
 import Breadcrumb from '../../components/Breadcrumb';
+import BlogCard from '../../components/BlogCard';
+import { getPostsByCategory } from '../../lib/blog';
+import styles from './Category.module.css';
 
-export default function BlogTutorials() {
+export default function BlogTutorials({ posts }) {
   return (
-    <main style={{ padding: 'var(--space-lg)' }}>
+    <main className={styles.container}>
       <Breadcrumb
         items={[
           { label: 'Accueil', href: '/' },
@@ -11,7 +14,20 @@ export default function BlogTutorials() {
         ]}
       />
       <h1>Tutoriels</h1>
-      <p>Les tutoriels arriveront prochainement.</p>
+      {posts.length > 0 ? (
+        <div className={`${styles.grid} responsive-grid`}>
+          {posts.map((p) => (
+            <BlogCard key={p.slug} {...p} />
+          ))}
+        </div>
+      ) : (
+        <p>Les tutoriels arriveront prochainement.</p>
+      )}
     </main>
   );
+}
+
+export async function getStaticProps() {
+  const posts = getPostsByCategory('tutorials');
+  return { props: { posts } };
 }


### PR DESCRIPTION
## Summary
- improve BlogCard typography rhythm with spacing and line-height tokens
- add reusable category and post page styles for responsive grids
- apply new styles to blog pages for consistent layout

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d25f48bfc8324b99828bf29478b5a