### PR TITLE
Add biography section with social links and CV link

### DIFF
--- a/a-propos/index.html
+++ b/a-propos/index.html
@@ -44,6 +44,17 @@
         <p class="tagline text-left">Studio d’animation 3D à Paris – créativité &amp; excellence.</p>
       </section>
 
+      <section class="biographie">
+        <h2 class="text-center">Biographie</h2>
+        <p class="text-left">Passionné par la création d’images de synthèse, Alex Chesnay est un artiste 3D basé à Paris. Retrouvez son parcours sur 
+          <a class="btn" href="https://www.linkedin.com/in/alexchesnay" target="_blank" rel="noopener">LinkedIn</a> et 
+          <a class="btn" href="https://www.artstation.com/alexchesnay" target="_blank" rel="noopener">ArtStation</a>.
+        </p>
+        <aside class="text-left">
+          <a class="btn-primary" href="/assets/AlexChesnay-CV.pdf" target="_blank" rel="noopener">Télécharger mon CV</a>
+        </aside>
+      </section>
+
       <section class="mission">
         <h2 class="text-center">Mission &amp; valeurs</h2>
         <p class="text-left">Notre mission est de donner vie aux idées grâce à des images de synthèse qui inspirent et convainquent.</p>

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -54,6 +54,41 @@ export default function APropos() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
+          <section style={{ margin: `${theme.spacing.lg} 0` }}>
+            <h2>Biographie</h2>
+            <p>
+              Passionné par la création d’images de synthèse, Alex Chesnay est un
+              artiste 3D basé à Paris. Retrouvez son parcours sur{' '}
+              <a
+                className="btn"
+                href="https://www.linkedin.com/in/alexchesnay"
+                target="_blank"
+                rel="noopener"
+              >
+                LinkedIn
+              </a>{' '}
+              et{' '}
+              <a
+                className="btn"
+                href="https://www.artstation.com/alexchesnay"
+                target="_blank"
+                rel="noopener"
+              >
+                ArtStation
+              </a>
+              .
+            </p>
+            <aside style={{ marginTop: theme.spacing.md }}>
+              <a
+                className="btn-primary"
+                href="/assets/AlexChesnay-CV.pdf"
+                target="_blank"
+                rel="noopener"
+              >
+                Télécharger mon CV
+              </a>
+            </aside>
+          </section>
           <Card>
             <h2>L'équipe</h2>
             <p>


### PR DESCRIPTION
## Summary
- add biography section on about page with LinkedIn and ArtStation links
- include CV download button styled with existing button classes

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration, cannot proceed)*

------
https://chatgpt.com/codex/tasks/task_e_689e370d35488324ba4f647e7537a24d