### PR TITLE
feat: add scroll reveal animations

### DIFF
--- a/components/FreeModels.js
+++ b/components/FreeModels.js
@@ -2,7 +2,12 @@ import theme from '../styles/theme';
 
 export default function FreeModels() {
   return (
-    <section className="free-models" style={{ margin: `${theme.spacing.lg} 0`, textAlign: 'center' }}>
+    <section
+      className="free-models"
+      style={{ margin: `${theme.spacing.lg} 0`, textAlign: 'center' }}
+      data-delay="0"
+      data-duration="600"
+    >
       <h2>Modèles gratuits</h2>
       <p>Découvrez notre collection de modèles 3D gratuits pour vos projets.</p>
       <a

--- a/components/SimilarItems.js
+++ b/components/SimilarItems.js
@@ -4,7 +4,12 @@ import theme from '../styles/theme';
 export default function SimilarItems({ items, imageSizes }) {
   if (!items || items.length === 0) return null;
   return (
-    <section className="similar-items" style={{ margin: `${theme.spacing.lg} 0` }}>
+    <section
+      className="similar-items"
+      style={{ margin: `${theme.spacing.lg} 0` }}
+      data-delay="0"
+      data-duration="600"
+    >
       <h2>Projets similaires</h2>
       <div className="grid">
         {items.map((p) => {

--- a/lib/scrollReveal.js
+++ b/lib/scrollReveal.js
@@ -1,0 +1,37 @@
+export const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export default function initScrollReveal() {
+  if (typeof window === 'undefined') return;
+
+  const sections = document.querySelectorAll('section');
+  if (!sections.length) return;
+
+  if (prefersReducedMotion()) {
+    sections.forEach((el) => {
+      el.classList.add('sr-visible');
+    });
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        const { delay = 0, duration = 600 } = el.dataset;
+        el.style.setProperty('--sr-delay', `${delay}ms`);
+        el.style.setProperty('--sr-duration', `${duration}ms`);
+        el.classList.add('sr-visible');
+        obs.unobserve(el);
+      }
+    });
+  }, {
+    threshold: 0.1
+  });
+
+  sections.forEach((el) => {
+    el.classList.add('sr');
+    observer.observe(el);
+  });
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import Footer from '../components/Layout/Footer';
 import CookieBanner from '../components/CookieBanner';
 import Preloader from '../components/Preloader';
 import theme from '../styles/theme';
+import initScrollReveal from '../lib/scrollReveal';
 
 export default function MyApp({ Component, pageProps }) {
   const router = useRouter();
@@ -25,6 +26,12 @@ export default function MyApp({ Component, pageProps }) {
       }
     }
   }, []);
+
+  useEffect(() => {
+    if (!loading) {
+      initScrollReveal();
+    }
+  }, [loading, router.asPath]);
 
   if (loading) {
     return <Preloader />;

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -54,7 +54,11 @@ export default function APropos() {
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
         >
-          <section style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Biographie</h2>
             <p>
               Passionné par la création d’images de synthèse, Alex Chesnay est un
@@ -97,7 +101,11 @@ export default function APropos() {
               expertise pour donner vie à vos projets.
             </p>
           </Card>
-          <section style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Historique</h2>
             <p>
               Depuis nos débuts, nous accompagnons studios et agences dans la
@@ -105,7 +113,11 @@ export default function APropos() {
               relever des défis toujours plus ambitieux.
             </p>
           </section>
-          <section style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Nos valeurs</h2>
             <p>
               Créativité, exigence et écoute sont au cœur de notre démarche. Nous
@@ -161,7 +173,11 @@ export default function APropos() {
               « Des résultats au-delà de nos attentes. » – Agence 123
             </blockquote>
           </Card>
-          <section style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Certifications et affiliations</h2>
             <p>
               Nous sommes <strong>Autodesk Certified</strong> et membres de la

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -63,8 +63,12 @@ export default function BlogPost({ post, prevPost, nextPost, relatedPosts }) {
             <Link href={`/blog/${nextPost.slug}`}>{`${nextPost.title} →`}</Link>
           )}
         </nav>
-        {relatedPosts.length > 0 && (
-          <section className={styles.related}>
+          {relatedPosts.length > 0 && (
+            <section
+              className={styles.related}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Articles similaires</h2>
             <div className={`${styles.grid} responsive-grid`}>
               {relatedPosts.map((p) => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,7 +56,11 @@ export default function Home() {
           </p>
         </FadeInSection>
 
-        <section style={{ padding: theme.spacing.lg }}>
+          <section
+            style={{ padding: theme.spacing.lg }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>En vedette</h2>
           <div className="responsive-grid">
             <Image
@@ -83,7 +87,11 @@ export default function Home() {
           </div>
         </section>
 
-        <section style={{ padding: theme.spacing.lg, backgroundColor: theme.colors.grey100 }}>
+          <section
+            style={{ padding: theme.spacing.lg, backgroundColor: theme.colors.grey100 }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Catégories</h2>
           <div className="responsive-grid">
             <div style={{ textAlign: 'center' }}>
@@ -119,7 +127,11 @@ export default function Home() {
           </div>
         </section>
 
-        <section style={{ padding: theme.spacing.lg }}>
+          <section
+            style={{ padding: theme.spacing.lg }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Extrait blog</h2>
           <div className="responsive-grid">
             <article>
@@ -137,7 +149,11 @@ export default function Home() {
           </div>
         </section>
 
-        <section style={{ padding: theme.spacing.lg, textAlign: 'center', backgroundColor: theme.colors.grey200 }}>
+          <section
+            style={{ padding: theme.spacing.lg, textAlign: 'center', backgroundColor: theme.colors.grey200 }}
+            data-delay="0"
+            data-duration="600"
+          >
           <Image
             src="/assets/images/MENNECHET_Alex_parfum_rendu1.jpg"
             alt="Contact"

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -41,19 +41,35 @@ export default function MentionsLegales() {
           ]}
         />
         <h1>Mentions légales</h1>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Éditeur du site</h2>
           <p>Alex Chesnay</p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Siège social</h2>
           <p>10 rue de la Liberté, 75000 Paris, France</p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Directeur de publication</h2>
           <p>Alex Chesnay</p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Hébergeur</h2>
           <p>
             Vercel Inc.<br />
@@ -62,11 +78,19 @@ export default function MentionsLegales() {
             États-Unis
           </p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Numéro SIREN / SIRET</h2>
           <p>123&nbsp;456&nbsp;789&nbsp;00000</p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Contact</h2>
           <p>
             <a href="mailto:alex-mennechet@outlook.fr">

--- a/pages/politique-de-confidentialite.js
+++ b/pages/politique-de-confidentialite.js
@@ -41,7 +41,11 @@ export default function PolitiqueDeConfidentialite() {
           ]}
         />
         <h1>Politique de confidentialité</h1>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Données collectées</h2>
           <p>
             Nous collectons les informations que vous nous fournissez via les formulaires de
@@ -49,14 +53,22 @@ export default function PolitiqueDeConfidentialite() {
             adresse e-mail et toute autre donnée fournie volontairement.
           </p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Finalités</h2>
           <p>
             Les données recueillies sont utilisées pour répondre à vos demandes, améliorer nos
             services et assurer le bon fonctionnement du site.
           </p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Durée de conservation</h2>
           <p>
             Vos informations sont conservées pendant une durée maximale de trois ans à compter de
@@ -64,7 +76,11 @@ export default function PolitiqueDeConfidentialite() {
             légales.
           </p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Droits des utilisateurs</h2>
           <p>
             Vous disposez d'un droit d'accès, de rectification, d'opposition, d'effacement et de
@@ -72,7 +88,11 @@ export default function PolitiqueDeConfidentialite() {
             traitement.
           </p>
         </section>
-        <section style={{ margin: `${theme.spacing.lg} 0` }}>
+          <section
+            style={{ margin: `${theme.spacing.lg} 0` }}
+            data-delay="0"
+            data-duration="600"
+          >
           <h2>Contact DPO</h2>
           <p>
             Pour toute question ou pour exercer vos droits, contactez notre délégué à la

--- a/pages/projects/[slug].js
+++ b/pages/projects/[slug].js
@@ -75,7 +75,7 @@ export default function Project({ project, prev, next, related }) {
           />
         </header>
         <div className="project-content" style={{ padding: theme.spacing.lg }}>
-          <section className="pitch">
+            <section className="pitch" data-delay="0" data-duration="600">
             <p>{project.description}</p>
           </section>
 
@@ -84,7 +84,12 @@ export default function Project({ project, prev, next, related }) {
             project.charDesigner ||
             project.production ||
             project.year) && (
-            <section className="project-meta" style={{ margin: `${theme.spacing.lg} 0` }}>
+              <section
+                className="project-meta"
+                style={{ margin: `${theme.spacing.lg} 0` }}
+                data-delay="0"
+                data-duration="600"
+              >
               <dl>
                 {project.workDone && (
                   <>
@@ -126,12 +131,22 @@ export default function Project({ project, prev, next, related }) {
             </section>
           )}
 
-          <section className="role" style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              className="role"
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Rôle</h2>
             <p>{project.role}</p>
           </section>
 
-          <section className="tools" style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              className="tools"
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Outils</h2>
             <ul>
               {project.tools.split(',').map((tool) => (
@@ -140,7 +155,12 @@ export default function Project({ project, prev, next, related }) {
             </ul>
           </section>
 
-          <section className="gallery" style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              className="gallery"
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Galerie</h2>
             <Gallery
               images={project.images}
@@ -150,7 +170,12 @@ export default function Project({ project, prev, next, related }) {
             />
           </section>
 
-          <section className="cta" style={{ margin: `${theme.spacing.lg} 0` }}>
+            <section
+              className="cta"
+              style={{ margin: `${theme.spacing.lg} 0` }}
+              data-delay="0"
+              data-duration="600"
+            >
             <h2>Intéressé ?</h2>
             <a className="contact-button" href="mailto:alex-mennechet@outlook.fr">
               Contactez-nous

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -88,7 +88,12 @@ export default function Projects({ projects }) {
             ))}
           </ul>
         </nav>
-        <section id="projects" className="project-gallery">
+          <section
+            id="projects"
+            className="project-gallery"
+            data-delay="0"
+            data-duration="600"
+          >
           <div className="grid">
             {filteredProjects.map((p) => {
               const size = imageSizes[p.images[0]] || { width: 800, height: 600 };

--- a/pages/store/facial-modeling-timelapse.js
+++ b/pages/store/facial-modeling-timelapse.js
@@ -63,7 +63,11 @@ export default function FacialModelingTimelapse() {
           GET IT NOW
         </a>
       </Card>
-      <section style={{ marginTop: 'var(--space-xl)' }}>
+        <section
+          style={{ marginTop: 'var(--space-xl)' }}
+          data-delay="0"
+          data-duration="600"
+        >
         <h2>Autres modèles disponibles</h2>
         <ul>
           <li>

--- a/pages/store/index.js
+++ b/pages/store/index.js
@@ -27,7 +27,11 @@ export default function StoreIndex() {
         ]}
       />
       <h1>Boutique</h1>
-      <section className="card-grid">
+        <section
+          className="card-grid"
+          data-delay="0"
+          data-duration="600"
+        >
         {products.map((product) => (
           <Card key={product.slug}>
             <img src={product.image} alt={product.title} width="640" height="360" />

--- a/pages/store/roller-derby-girl.js
+++ b/pages/store/roller-derby-girl.js
@@ -63,7 +63,11 @@ export default function RollerDerbyGirl() {
           GET IT NOW
         </a>
       </Card>
-      <section style={{ marginTop: 'var(--space-xl)' }}>
+        <section
+          style={{ marginTop: 'var(--space-xl)' }}
+          data-delay="0"
+          data-duration="600"
+        >
         <h2>Autres modèles disponibles</h2>
         <ul>
           <li>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -416,3 +416,23 @@ button:focus-visible {
 .gallery--slider .gallery__next {
   right: 8px;
 }
+section.sr {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+section.sr-visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity var(--sr-duration, 600ms) ease-out var(--sr-delay, 0ms),
+    transform var(--sr-duration, 600ms) ease-out var(--sr-delay, 0ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  section.sr,
+  section.sr-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add IntersectionObserver-based scrollReveal utility with reduced motion check
- expose global reveal styles and initialize in _app
- annotate sections with configurable data-delay and data-duration attributes

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689e4e33d9e08324961f5413fbba4c78