### PR TITLE
Animate header shrink on scroll

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -60,8 +60,7 @@ export default function Header() {
         style={{
           background: theme.colors.background,
           borderBottom: `1px solid ${theme.colors.text}`,
-          color: theme.colors.text,
-          padding: 'var(--space-md) 0'
+          color: theme.colors.text
         }}
       >
         <div className="container">

--- a/components/Layout/Header.module.css
+++ b/components/Layout/Header.module.css
@@ -4,11 +4,15 @@
   left: 0;
   right: 0;
   box-shadow: none;
-  transition: box-shadow 0.3s ease;
+  padding: var(--space-md) 0;
+  height: 80px;
+  transition: box-shadow 0.3s ease, padding 0.25s ease, height 0.25s ease;
 }
 
 .scrolled {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: var(--space-sm) 0;
+  height: 60px;
 }
 
 .nav-inner {


### PR DESCRIPTION
## Summary
- Reduce header padding and height when scrolled with smooth 0.25s transition
- Ensure header component toggles `scrolled` state based on window scroll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5034dd90832482a59711f99077eb